### PR TITLE
fixed region extraction - all buckets are skipped

### DIFF
--- a/scripts/060-get-s3.sh
+++ b/scripts/060-get-s3.sh
@@ -14,7 +14,7 @@ fi
 pref[0]="Buckets"
 tft[0]="aws_s3_bucket"
 idfilt[0]="Name"
-theregion=`grep region aws.tf | head -1 | cut -f2 -d'=' | tr -d '"' | tr -d ' '`
+theregion=`echo "var.region" | terraform console | tr -d '"'`
 keyid=""
 doacl2=0
  

--- a/scripts/090-get-cloudtrail.sh
+++ b/scripts/090-get-cloudtrail.sh
@@ -5,7 +5,7 @@ tft[0]="aws_cloudtrail"
 idfilt[0]="SubnetId"
 
 for c in `seq 0 0`; do
-    region=`cat aws.tf | grep region | awk '{print $3}' | tr -d '"'`
+    region=`echo "var.region" | terraform console | tr -d '"'`
     cm=${cmd[$c]}
 	ttft=${tft[(${c})]}
 	#echo $cm


### PR DESCRIPTION
used terraform console interpolation for "future proof extraction".

*Issue #, if available:*
region variable migrated from 'aws.tf' to a generated 'main-vars.tf'

#scripts/060-get-s3.sh:17 
```
theregion=`grep region aws.tf | head -1 | cut -f2 -d'=' | tr -d '"' | tr -d ' '`
```

will now extract the wrong value 'var.region' literally instead of the calculated region thus resulting in always false for the next condition

#scripts/060-get-s3.sh:65:408 
```
if [[ "$br" == "$theregion" ]]; then
.
.
.
echo "Bucket $cname not in current region $theregion 

```
*Description of changes:*
changed 

#scripts/060-get-s3.sh:17 
from    region=`cat aws.tf | grep region | awk '{print $3}' | tr -d '"'`
to   region=`echo "var.region" | terraform console | tr -d '"'`

#scripts/090-get-cloudtrail.sh:8
from  region=`cat aws.tf | grep region | awk '{print $3}' | tr -d '"'`
to   region=`echo "var.region" | terraform console | tr -d '"'`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
