### PR TITLE
Update 060-get-s3.sh for us-east-1 "null" result from get-bucket-location

### DIFF
--- a/scripts/060-get-s3.sh
+++ b/scripts/060-get-s3.sh
@@ -2,10 +2,10 @@
 bucks=()
 if [ "$1" != "" ]; then
     if [[ $1 != "*" ]];then
-        bucks+=$($AWS s3api list-buckets --query Buckets[*].Name | jq -r .[] | grep $1)
+        bucks+=$(AWS s3api list-buckets --query Buckets[*].Name | jq -r .[] | grep $1)
     fi
 else
-    bucks+=$($AWS s3api list-buckets --query Buckets[*].Name | jq -r .[])
+    bucks+=$(AWS s3api list-buckets --query Buckets[*].Name | jq -r .[])
 fi
 
 if [ "$bucks" == "" ]; then
@@ -34,16 +34,16 @@ for cname in ${bucks[@]}; do
         if [ -f "$fn" ]; then echo "$fn exists already skipping" && continue; fi
 
         # check region & access
-        br=$($AWS s3api get-bucket-location --bucket ${cname})
+        br=$(AWS s3api get-bucket-location --bucket ${cname})
         if [ $? -ne 0 ]; then
-            br="null"
+            br="none"
             echo "Cannot access buck $cname - skipping ..."
             continue
         else
             br=$(echo $br | jq .LocationConstraint | tr -d '"')
         fi
 
-        if [[ "$br" == "$theregion" ]]; then
+        if [[ "$br" == "$theregion" ]] || [[ $br == "null"  &&  "$theregion" == "us-east-1" ]]; then
 
             echo "$ttft $cname Import"
             bucklist+=$(echo "$cname ")


### PR DESCRIPTION
My buckets in us-east-1were being skipped.
The s3api get-bucket-location will return null for buckets in us-east-1. This resulted in the us-east-1 buckets being skipped when they failed the "$br" == "$theregion" test . 
Documentation page at https://awscli.amazonaws.com/v2/documentation/api/latest/reference/s3api/get-bucket-location.html says: "Buckets in Region us-east-1 have a LocationConstraint of null ."

Also, the extra $ in $($AWS commands was causing a problem in my testing. May be extraneous?

*Issue #, if available: NA

*Description of changes:
Modified the if statement checking bucket location to accept "null" if region is us-east-1. 
Also removed null from the "if [ $? -ne 0 ];" error code check result to avoid it being a valid value for us-east-1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
