### PR TITLE
Fix KeyError in `get_aws_route_table_association` for IGW associations

### DIFF
--- a/code/get_aws_resources/aws_ec2.py
+++ b/code/get_aws_resources/aws_ec2.py
@@ -415,26 +415,32 @@ def get_aws_route_table_association(type, id, clfn, descfn, topkey, key, filteri
                      if not ismain:
                         #print("Trying .......")
                         try:
-                           subid = str(item['Associations'][r]['SubnetId'])
-                            
-                           #print("in pre-rproc.... subid="+str(subid)+" ismain="+str(ismain)+" vpcid="+str(vpcid))
+                            if 'SubnetId' in item['Associations'][r]:
+                                subid = str(item['Associations'][r]['SubnetId'])
+                                #print("in pre-rproc.... subid="+str(subid)+" ismain="+str(ismain)+" vpcid="+str(vpcid))
 
-                           # TODO wrong check ? if don't have subnet should add as dependancy
-                           # if subid in str(globals.rproc):
+                                # TODO wrong check ? if don't have subnet should add as dependancy
+                                # if subid in str(globals.rproc):
 
-                           # TODO check if already have the association
-                           #print("--10a--- id="+str(id)+" subid="+subid+" rtid="+rtid)
-                           if id is not None and "subnet-" in id:
-                              if subid == id:
-                                 theid = subid+"/"+rtid
-                                 common.write_import(type, theid, None)
-                                 pkey = type+"."+subid
-                                 globals.rproc[pkey] = True
-                           else:
-                              theid = subid+"/"+rtid
-                              common.write_import(type, theid, None)
-                              pkey = type+"."+subid
-                              globals.rproc[pkey] = True
+                                # TODO check if already have the association
+                                #print("--10a--- id="+str(id)+" subid="+subid+" rtid="+rtid)
+                                if id is not None and "subnet-" in id:
+                                    if subid == id:
+                                        theid = subid+"/"+rtid
+                                        common.write_import(type, theid, None)
+                                        pkey = type+"."+subid
+                                        globals.rproc[pkey] = True
+                                else:
+                                    theid = subid+"/"+rtid
+                                    common.write_import(type, theid, None)
+                                    pkey = type+"."+subid
+                                    globals.rproc[pkey] = True
+                            elif 'GatewayId' in item['Associations'][r]:
+                                gwid = str(item['Associations'][r]['GatewayId'])
+                                theid = gwid+"/"+rtid
+                                common.write_import(type, theid, None)
+                                pkey = type+"."+gwid
+                                globals.rproc[pkey] = True
 
                         except Exception as e:
                            common.handle_error(e,str(inspect.currentframe().f_code.co_name),clfn,descfn,topkey,id)


### PR DESCRIPTION
I encountered an issue where my route table had an associated Internet Gateway (IGW), which caused a `KeyError` when running this script. The script previously assumed all associations included a `SubnetId`, but IGW associations only contain a `GatewayId`. This fix ensures proper handling of IGW-associated route tables.
![aws_ec2_py_error_log](https://github.com/user-attachments/assets/6dc6216f-4048-4669-8571-5a19c8c1db44)

- Handle cases where a route table is associated with an Internet Gateway (IGW).
- Prevent KeyError by checking if `GatewayId` exists before accessing it.
- Separate processing for `GatewayId` to correctly manage IGW associations.
- Enhance stability when importing route table associations.

*Issue #, if available: NA

*Description of changes:
Added a conditional check for `SubnetId` before attempting to access it.
Introduced a separate condition for `GatewayId` to handle IGW associations correctly.
Ensured `GatewayId` associations are processed separately to avoid errors when importing route tables.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
