### PR TITLE
fix: route53 wildcards

### DIFF
--- a/code/common.py
+++ b/code/common.py
@@ -962,10 +962,10 @@ def write_import(type,theid,tfid):
       ## todo -  if theid starts with a number or is an od (but what if its hexdecimal  ?)
 
       if tfid is None:
-            tfid=theid.replace("/","_").replace(".","_").replace(":","_").replace("|","_").replace("$","_").replace(",","_").replace("&","_").replace("#","_").replace("[","_").replace("]","_").replace("=","_").replace("!","_").replace(";","_").replace(" ","_")
+            tfid=theid.replace("/","_").replace(".","_").replace(":","_").replace("|","_").replace("$","_").replace(",","_").replace("&","_").replace("#","_").replace("[","_").replace("]","_").replace("=","_").replace("!","_").replace(";","_").replace(" ","_").replace("*","star").replace("\\052","star")
       else:
-            tfid=tfid.replace("/", "_").replace(".", "_").replace(":", "_").replace("|", "_").replace("$", "_").replace(",","_").replace("&","_").replace("#","_").replace("[","_").replace("]","_").replace("=","_").replace("!","_").replace(";","_").replace(" ","_")
-         
+            tfid=tfid.replace("/", "_").replace(".", "_").replace(":", "_").replace("|", "_").replace("$", "_").replace(",","_").replace("&","_").replace("#","_").replace("[","_").replace("]","_").replace("=","_").replace("!","_").replace(";","_").replace(" ","_").replace("*","star").replace("\\052","star")
+
          #catch tfid starts with number
       if tfid[:1].isdigit(): tfid="r-"+tfid
 

--- a/code/get_aws_resources/aws_route53.py
+++ b/code/get_aws_resources/aws_route53.py
@@ -14,16 +14,16 @@ def get_aws_route53_zone(type, id, clfn, descfn, topkey, key, filterid):
             paginator = client.get_paginator(descfn)
             for page in paginator.paginate():
                 response = response + page[topkey]
-            if response == []: 
+            if response == []:
                 print("Empty response for "+type+ " id="+str(id)+" returning")
                 return True
             for j in response:
-                common.write_import(type,j[key],None) 
+                common.write_import(type,j[key],None)
                 common.add_dependancy("aws_route53_record",j[key])
 
-        else:      
+        else:
             response = client.get_hosted_zone(Id=id)
-            if response['HostedZone'] == []: 
+            if response['HostedZone'] == []:
                 print("Empty response for "+type+ " id="+str(id)+" returning")
                 return True
             j=response['HostedZone']
@@ -45,7 +45,7 @@ def get_aws_route53_record(type, id, clfn, descfn, topkey, key, filterid):
         client = boto3.client(clfn)
         if id is None:
             print("WARNING: No id or invalid provided for "+type)
-        else:   
+        else:
             rkey=type+"."+id
             globals.rproc[rkey]=True
             if id.startswith("/hostedzone/"): id=id.split("/")[2]
@@ -53,7 +53,7 @@ def get_aws_route53_record(type, id, clfn, descfn, topkey, key, filterid):
             paginator = client.get_paginator(descfn)
             for page in paginator.paginate(HostedZoneId=id):
                 response = response + page[topkey]
-            if response == []: 
+            if response == []:
                 print("Empty response for "+type+ " id="+str(id)+" returning")
                 return True
             for j in response:
@@ -62,8 +62,11 @@ def get_aws_route53_record(type, id, clfn, descfn, topkey, key, filterid):
                 r53type=j['Type']
                 if r53name.endswith("."): r53name=r53name[:-1]
                 if r53type=="A":
-                    pkey=id+"_"+r53name+"_"+r53type
-                    common.write_import(type,pkey,None) 
+                    import_id = id+"_"+r53name+"_"+r53type
+                    import_id = import_id.replace("\\052", "*")
+                    resource_name = id+"_"+r53name.replace("*", "star").replace("\\052", "star")+"_"+r53type
+
+                    common.write_import(type, import_id, resource_name)
 
     except Exception as e:
         common.handle_error(e,str(inspect.currentframe().f_code.co_name),clfn,descfn,topkey,id)


### PR DESCRIPTION
This commit fixes the import of route53 wildcard records to properly translate the octal value to a wildcard for the zone ID and to use "star" for the resource title.

Prior to this, importing route53 resources with wildcard records failed - the resource block was not generated and the filename and import ID contained the octal value.

Example of error:

>  Error: Invalid character
>
>    on import__aws_route53_record__Z00000000000000000XYZ_\052_foo_com_A.tf line 2, in import:
>     2:   to = aws_route53_record.Z00000000000000000XYZ_\052_foo_com_A
>
>  This character is not used within the language.
>
>
>  Error: Missing newline after argument
>
>    on import__aws_route53_record__Z00000000000000000XYZ_\052_foo_com_A.tf line 2, in import:
>     2:   to = aws_route53_record.Z00000000000000000XYZ_\052_foo_com_A
>
>  An argument definition must end with a newline.
>
>
>  Error: Invalid escape sequence
>
>    on import__aws_route53_record__Z00000000000000000XYZ_\052_foo_com_A.tf line 3, in import:
>     3:   id = "Z04499992N02APSCWVVKR_\052.foo.com_A"
>
>  The symbol "0" is not a valid escape sequence selector.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
