### PR TITLE
Fix private NAT gateway generating invalid aws_eip.null reference

### DIFF
--- a/code/fixtf_aws_resources/fixtf_ec2.py
+++ b/code/fixtf_aws_resources/fixtf_ec2.py
@@ -123,8 +123,11 @@ def aws_eip_association(t1, tt1, tt2, flag1, flag2):
 	elif tt1 == "private_ip_address": skip = 1
 	elif tt1 == "network_interface_id": skip = 1
 	elif tt1 == "allocation_id":
-		t1 = tt1 + " = aws_eip." + tt2 + ".id\n"
-		common.add_dependancy("aws_eip", tt2)
+		if tt2 == "null" or tt2 == "":
+			skip = 1
+		else:
+			t1 = tt1 + " = aws_eip." + tt2 + ".id\n"
+			common.add_dependancy("aws_eip", tt2)
 	return skip, t1, flag1, flag2
 
 
@@ -240,8 +243,11 @@ def aws_nat_gateway(t1, tt1, tt2, flag1, flag2):
 	elif tt1 == "private_ip": skip = 1
 	elif tt1 == "public_ip": skip = 1
 	elif tt1 == "allocation_id":
-		t1 = tt1 + " = aws_eip." + tt2 + ".id\n"
-		common.add_dependancy("aws_eip", tt2)
+		if tt2 == "null" or tt2 == "":
+			skip = 1  # private NAT gateways have no EIP
+		else:
+			t1 = tt1 + " = aws_eip." + tt2 + ".id\n"
+			common.add_dependancy("aws_eip", tt2)
 	elif tt1 == "vpc_id":
 		t1 = t1 + "\n lifecycle {\n   ignore_changes = [regional_nat_gateway_address]\n}\n"
 	return skip, t1, flag1, flag2


### PR DESCRIPTION
Encountered an issue where private NAT gateways have `allocation_id = null` since they don't use Elastic IPs. The script previously converted `allocation_id` unconditionally to an `aws_eip.{value}` reference, producing `aws_eip.null.id` which causes the dependency resolution loop to fail with exit 011.

- Handle cases where a NAT gateway is private and has no associated EIP.
- Prevent invalid `aws_eip.null` reference by checking if `allocation_id` is null or empty.
- Guard both `aws_nat_gateway()` and `aws_eip_association()` handlers to skip the line accordingly.
- Tested with both public and private NAT gateways to ensure stability.

**Issue #, if available:** NA

*Description of changes:
Added a null/empty check on `allocation_id` before generating the `aws_eip` reference.
When `allocation_id` is null, the line is skipped instead of producing an invalid resource reference.
Public NAT gateways still get the correct `aws_eip.*` reference, private ones skip the line.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.