### PR TITLE
fix: keep account-portable role ARNs literal in policy documents (#133)

### DIFF
--- a/code/fixtf.py
+++ b/code/fixtf.py
@@ -846,7 +846,13 @@ def globals_replace(t1,tt1,tt2):
             return t1
 
         if tt2.startswith("arn:aws:iam") and ":role/" in tt2:
-            if tt2.endswith("*"): 
+            if tt2.endswith("*"):
+                return t1
+            # account-portable ARN (wildcard/empty account, common in AWS-managed
+            # policy copies, e.g. arn:aws:iam::*:role/aws-service-role/...): keep
+            # the literal ARN; de-referencing would pin the account -> perpetual drift
+            arnparts=tt2.split(":")
+            if len(arnparts) > 4 and arnparts[4] in ("", "*"):
                 return t1
             tt2=tt2.split('/')[-1]
             if tt2 in context.rolelist:


### PR DESCRIPTION
### What
In `globals_replace()` (`code/fixtf.py`), keep the **literal** role ARN when the ARN's account segment is empty or `*`, instead of de-referencing it to `aws_iam_role.<name>.arn`.

### Why
Customer-managed policies that copy AWS-managed policies reference service-linked roles with an account-portable ARN, e.g. `arn:aws:iam::*:role/aws-service-role/eks.amazonaws.com/AWSServiceRoleForAmazonEKS`. The existing branch only skips ARNs that *end* with `*`, so these get de-referenced and the reference resolves to the concrete account at plan time. AWS stores the policy with the original `*`/empty account, so `terraform plan` reports a never-converging in-place change.

### How
Add an account-segment guard (`arn.split(":")[4] in ("", "*")`) right after the existing `endswith("*")` check. Real-account role ARNs continue to de-reference unchanged.

Fixes #133

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's LICENSE.
