### PR TITLE
fix: handle provider-invalid permissions_boundary account via ignore_changes (#134)

### DIFF
--- a/code/fixtf_aws_resources/fixtf_iam.py
+++ b/code/fixtf_aws_resources/fixtf_iam.py
@@ -91,8 +91,20 @@ def aws_iam_role(t1,tt1,tt2,flag1,flag2):
 	elif tt1 == "permissions_boundary" and tt2 != "null":
 		if "arn:aws:iam::aws:policy" not in tt2:
 			pn=tt2.split("/")[-1]
-			common.add_dependancy("aws_iam_policy",tt2)
-			t1=tt1+" = aws_iam_policy."+pn+".arn\n"
+			bparts=tt2.split(":")
+			bacct=bparts[4] if len(bparts) > 4 else ""
+			# the provider's ARN validator only accepts these account-id forms
+			valid_acct=(len(bacct)==12 and bacct.isdigit()) or bacct in ("aws","aws-managed","third-party","aws-marketplace") or (len(bacct)==12 and bacct.startswith("cw"))
+			if not valid_acct:
+				# Non-standard account segment (e.g. a vendor-issued boundary) that
+				# the provider's ARN validator rejects: keeping the literal fails
+				# `terraform validate`, and dropping it makes terraform plan to
+				# REMOVE the live boundary. Drop it and ignore_changes so the live
+				# boundary is left untouched.
+				t1="  lifecycle {\n    ignore_changes = [permissions_boundary]\n  }\n"
+			else:
+				common.add_dependancy("aws_iam_policy",tt2)
+				t1=tt1+" = aws_iam_policy."+pn+".arn\n"
 	elif tt1 == "managed_policy_arns":   
 		if tt2 == "[]": 
 			skip=1


### PR DESCRIPTION
### What
In `aws_iam_role()` (`code/fixtf_aws_resources/fixtf_iam.py`), when a role's `permissions_boundary` ARN has an account segment the AWS provider's ARN validator rejects, drop the literal attribute and emit `lifecycle { ignore_changes = [permissions_boundary] }` instead.

### Why
Some roles carry a boundary whose ARN account segment is not a 12-digit id (e.g. a vendor/third-party-issued boundary). Keeping the literal fails `terraform validate` (`invalid account ID value`); dropping it makes `terraform plan` want to remove the live boundary on apply. Neither is acceptable.

### How
Detect a provider-invalid account segment (anything not matching `aws | aws-managed | third-party | aws-marketplace | 12-digit | cw + 10 chars`). In that case emit the `ignore_changes` lifecycle (permissions_boundary is Optional+Computed, so this is valid) — `validate` passes and the live boundary is left untouched. Valid-account boundaries keep the existing behaviour (reference the imported policy).

Fixes #134

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's LICENSE.
