### PR TITLE
fix: avoid metric_transformation.unit import drift via ignore_changes (#135)

### DIFF
--- a/code/fixtf_aws_resources/fixtf_logs.py
+++ b/code/fixtf_aws_resources/fixtf_logs.py
@@ -47,7 +47,20 @@ def aws_cloudwatch_log_stream(t1, tt1, tt2, flag1, flag2):
 		# Add dependency so aws2tf imports the log group automatically
 		common.add_dependancy("aws_cloudwatch_log_group", tt2)
     
-	return skip, t1, flag1, flag2 
+	return skip, t1, flag1, flag2
+
+
+def aws_cloudwatch_log_metric_filter(t1, tt1, tt2, flag1, flag2):
+    skip = 0
+    # The provider defaults metric_transformation.unit to "None", but AWS returns
+    # "" for filters created without a unit, giving a perpetual in-place diff on
+    # import. unit cannot be set to "" (fails the provider's StandardUnit
+    # validation), so ignore changes to it. Hooked on log_group_name (a required,
+    # top-level, single-occurrence attribute) so the lifecycle block lands at the
+    # resource level.
+    if tt1 == "log_group_name":
+        t1 = t1 + "\n  lifecycle {\n    ignore_changes = [metric_transformation[0].unit]\n  }\n"
+    return skip, t1, flag1, flag2
 
 
 


### PR DESCRIPTION
### What
Add an `aws_cloudwatch_log_metric_filter` handler in `code/fixtf_aws_resources/fixtf_logs.py` that emits `lifecycle { ignore_changes = [metric_transformation[0].unit] }`.

### Why
For a metric filter created without a unit, AWS returns an empty unit but the provider defaults `metric_transformation.unit` to `"None"`, so every `terraform plan` shows a permanent `~ unit = "" -> "None"`. It can't be resolved by value: `unit = ""` fails the provider's `StandardUnit` validation, and dropping the attribute still applies the `"None"` default.

### How
A small handler hooked on the required, top-level `log_group_name` attribute so the lifecycle block lands at resource level.

Tradeoff: `unit` is ignored for all metric filters, so a deliberate unit change would also be ignored — acceptable for a faithful import; happy to scope more narrowly if preferred.

Fixes #135

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's LICENSE.
