### PR TITLE
fix: drop invalid aws_cloudwatch_metric_alarm fields (#147)

### DIFF
--- a/code/fixtf_aws_resources/fixtf_cloudwatch.py
+++ b/code/fixtf_aws_resources/fixtf_cloudwatch.py
@@ -8,6 +8,17 @@ import context
 def aws_cloudwatch_metric_alarm(t1, tt1, tt2, flag1, flag2):
     """Handler for aws_cloudwatch_metric_alarm resource"""
     skip = 0
+    # datapoints_to_alarm must be >= 1; AWS returns 0 when it was never set.
+    # Drop the line so the provider uses its default.
+    if tt1 == "datapoints_to_alarm" and tt2 == "0":
+        skip = 1
+    # empty dimensions map conflicts with metric_query - drop it
+    elif tt1 == "dimensions" and tt2 == "{}":
+        skip = 1
+    # period/threshold-style scalars are 0 when metric_query is used; period=0
+    # both is invalid and conflicts with metric_query - drop it
+    elif tt1 == "period" and tt2 == "0":
+        skip = 1
     return skip, t1, flag1, flag2
 
 def aws_cloudwatch_composite_alarm(t1, tt1, tt2, flag1, flag2):


### PR DESCRIPTION
### What
In the `aws_cloudwatch_metric_alarm` handler, skip `datapoints_to_alarm = 0`, `dimensions = {}`, and `period = 0`.

### Why
AWS returns 0/empty for these when unset; emitting them fails validation (`datapoints_to_alarm` must be >= 1) or conflicts with a `metric_query` block. Skipping them lets the provider use its defaults / the `metric_query` block.

Fixes #147

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's LICENSE.
