### PR TITLE
fix: provider-schema conformance for s3/eks/sqs/lb/transfer (#148)

### DIFF
--- a/code/fixtf_aws_resources/fixtf_eks.py
+++ b/code/fixtf_aws_resources/fixtf_eks.py
@@ -106,10 +106,15 @@ def aws_eks_node_group(t1,tt1,tt2,flag1,flag2):
         flag1=True
 
 
-    if "max_unavailable_percentage" in tt1: 
+    if "max_unavailable_percentage" in tt1:
         if tt2 == "0": skip=1
 
     elif "max_unavailable" in tt1:
+        if tt2 == "0": skip=1
+
+    # node_repair_config: *_count conflicts with *_percentage; AWS returns all 0
+    # when unset. Drop the zero-valued numerics, leaving enabled=false.
+    elif tt1 in ("max_parallel_nodes_repaired_count","max_parallel_nodes_repaired_percentage","max_unhealthy_node_threshold_count","max_unhealthy_node_threshold_percentage"):
         if tt2 == "0": skip=1
 
     elif "node_group_name_prefix" in tt1: skip=1

--- a/code/fixtf_aws_resources/fixtf_elbv2.py
+++ b/code/fixtf_aws_resources/fixtf_elbv2.py
@@ -34,8 +34,12 @@ def aws_lb_listener(t1,tt1,tt2,flag1,flag2):
 	if "order" == tt1:
 		if tt2 == "0": skip=1
 	elif "duration" == tt1:
-		if tt2 == "0": t1=tt1+" = 1\n"	
+		if tt2 == "0": t1=tt1+" = 1\n"
 		#if tt2 == "0": skip=1
+	elif "ignore_client_certificate_expiry" == tt1:
+		# only valid when mutual_authentication mode = "verify"; false is the
+		# default and conflicts when mode = "off", so drop it
+		if tt2 == "false": skip=1
 
 	return skip,t1,flag1,flag2
 
@@ -61,10 +65,21 @@ def aws_lb_listener_rule(t1,tt1,tt2,flag1,flag2):
 
 
 
+def aws_lb(t1,tt1,tt2,flag1,flag2):
+
+
+	skip=0
+	# name_prefix conflicts with name; imported resources always have a name
+	if tt1 == "name_prefix": skip=1
+	return skip,t1,flag1,flag2
+
+
 def aws_lb_target_group(t1,tt1,tt2,flag1,flag2):
 
 
 	skip=0
+	# name_prefix conflicts with name; imported resources always have a name
+	if tt1 == "name_prefix": skip=1
 	if "on_deregistration" in tt1:
 		if tt2 == "null": t1=tt1+" = \"no_rebalance\"\n"
 	if "on_unhealthy" in tt1:

--- a/code/fixtf_aws_resources/fixtf_s3.py
+++ b/code/fixtf_aws_resources/fixtf_s3.py
@@ -59,7 +59,11 @@ def aws_s3_bucket_lifecycle_configuration(t1, tt1, tt2, flag1, flag2):
 	# Skip null values for mutually exclusive expiration fields
 	if tt1 in ["date", "days", "expired_object_delete_marker"] and tt2 == "null":
 		skip = 1
-	
+	# expiration requires exactly one of date/days/expired_object_delete_marker;
+	# AWS often returns days alongside expired_object_delete_marker=false - drop it
+	if tt1 == "expired_object_delete_marker" and tt2 == "false":
+		skip = 1
+
 	# Add lifecycle ignore block for the bucket field
 	if tt1 == "bucket":
 		t1 = t1 + "\n lifecycle {\n   ignore_changes = [rule]\n}\n"

--- a/code/fixtf_aws_resources/fixtf_sqs.py
+++ b/code/fixtf_aws_resources/fixtf_sqs.py
@@ -15,6 +15,18 @@ from .base_handler import BaseResourceHandler
 log = logging.getLogger('aws2tf')
 
 
+def aws_sqs_queue(t1, tt1, tt2, flag1, flag2):
+	skip = 0
+	# kms_master_key_id conflicts with sqs_managed_sse_enabled. Keep whichever is
+	# actually set: drop a null kms key, and drop sqs_managed_sse_enabled=false
+	# (its default) so a queue using a real KMS key validates.
+	if tt1 == "kms_master_key_id" and tt2 == "null":
+		skip = 1
+	elif tt1 == "sqs_managed_sse_enabled" and tt2 == "false":
+		skip = 1
+	return skip, t1, flag1, flag2
+
+
 # ============================================================================
 # Magic method for backward compatibility with getattr()
 # ============================================================================

--- a/code/fixtf_aws_resources/fixtf_transfer.py
+++ b/code/fixtf_aws_resources/fixtf_transfer.py
@@ -10,9 +10,23 @@ Reduction: 0% less code
 """
 
 import logging
+import context
 from .base_handler import BaseResourceHandler
 
 log = logging.getLogger('aws2tf')
+
+
+def aws_transfer_server(t1, tt1, tt2, flag1, flag2):
+	skip = 0
+	# vpc_endpoint_id is only valid for the (deprecated) VPC_ENDPOINT endpoint
+	# type; for the VPC endpoint type it conflicts with address_allocation_ids.
+	# endpoint_type appears before endpoint_details, so remember it.
+	if tt1 == "endpoint_type":
+		context.transfer_endpoint_type = tt2
+	elif tt1 == "vpc_endpoint_id":
+		if getattr(context, "transfer_endpoint_type", "") != "VPC_ENDPOINT":
+			skip = 1
+	return skip, t1, flag1, flag2
 
 
 # ============================================================================


### PR DESCRIPTION
### What
Provider-schema conformance fixes so generated config validates/plans:

- `s3_bucket_lifecycle_configuration`: drop `expired_object_delete_marker` when it conflicts with `days`
- `eks_node_group`: drop zero `node_repair_config` `*_count`/`*_percentage`
- `sqs_queue`: drop `kms_master_key_id`/`sqs_managed_sse_enabled` when they conflict
- `lb` / `lb_target_group`: drop `name_prefix` (conflicts with `name`); `lb_listener` mutual-auth tidy-ups
- `transfer_server`: drop `vpc_endpoint_id` for the VPC endpoint type (conflicts with `address_allocation_ids`)

Fixes #148

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's LICENSE.
