### PR TITLE
fix: correct RDS/backup/transfer getters (#149)

### DIFF
--- a/code/fixtf_aws_resources/aws_dict.py
+++ b/code/fixtf_aws_resources/aws_dict.py
@@ -9958,8 +9958,8 @@ aws_transfer_workflow = {
 	"clfn":		"transfer",
 	"descfn":	"list_workflows",
 	"topkey":	"Workflows",
-	"key":		"Arn",
-	"filterid":	"Arn"
+	"key":		"WorkflowId",
+	"filterid":	"WorkflowId"
 }
 
 aws_verifiedaccess_endpoint = {

--- a/code/get_aws_resources/aws_backup.py
+++ b/code/get_aws_resources/aws_backup.py
@@ -68,8 +68,20 @@ def get_aws_backup_plan(type, id, clfn, descfn, topkey, key, filterid):
                 log.debug("Empty response for "+type+ " id="+str(id)+" returning")
                 return True
             for j in response:
-                if "/" not in j['BackupPlanName']:
-                    common.write_import(type,j[key],None) 
+                if "/" in j['BackupPlanName']:
+                    continue
+                # Service-managed plans (e.g. AWS RDS automatic backups) use rule
+                # names containing '/', which are invalid Terraform rule_name
+                # values and cannot be imported - skip them.
+                try:
+                    det = client.get_backup_plan(BackupPlanId=j[key])
+                    rules = det.get('BackupPlan', {}).get('Rules', [])
+                    if any("/" in r.get('RuleName', '') for r in rules):
+                        log.info("Skipping service-managed backup plan %s (invalid rule_name)", j['BackupPlanName'])
+                        continue
+                except Exception:
+                    pass
+                common.write_import(type,j[key],None)
 
         else:      
             response = client.get_backup_plan(BackupPlanId=id)

--- a/code/get_aws_resources/aws_rds.py
+++ b/code/get_aws_resources/aws_rds.py
@@ -11,6 +11,62 @@ import sys
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
+def get_aws_db_snapshot(type, id, clfn, descfn, topkey, key, filterid):
+    # Only MANUAL snapshots are importable as aws_db_snapshot. describe_db_snapshots
+    # also returns automated ("rds:" prefix) and AWS Backup ("awsbackup:" prefix)
+    # snapshots, which are service-managed and fail import with
+    # "Cannot import non-existent remote object".
+    if context.debug:
+        log.debug("--> In get_aws_db_snapshot doing " + type + ' with id ' + str(id))
+    try:
+        response = []
+        client = boto3.client(clfn)
+        paginator = client.get_paginator(descfn)
+        for page in paginator.paginate():
+            response = response + page[topkey]
+        if response == []:
+            log.debug("Empty response for "+type+" id="+str(id)+" returning"); return True
+        for j in response:
+            if j.get('SnapshotType') != 'manual':
+                continue
+            if id is None or id == j.get(filterid):
+                common.write_import(type, j[key], None)
+    except Exception as e:
+        common.handle_error(e, str(inspect.currentframe().f_code.co_name), clfn, descfn, topkey, id)
+
+    return True
+
+
+def get_aws_db_instance_automated_backups_replication(type, id, clfn, descfn, topkey, key, filterid):
+    # aws_db_instance_automated_backups_replication manages *cross-region*
+    # automated-backup replication. describe_db_instance_automated_backups returns
+    # both local backups and replicas, and its read uses the
+    # DB_INSTANCE_AUTOMATED_BACKUPS_ARN filter - so the import id must be the
+    # automated-backup ARN (...:auto-backup:ab-...), NOT the db instance ARN. A
+    # local backup (source region == current region) is part of the db_instance and
+    # is not a replication resource, so only emit genuine cross-region replicas.
+    if context.debug:
+        log.debug("--> In get_aws_db_instance_automated_backups_replication doing " + type + ' with id ' + str(id))
+    try:
+        response = []
+        client = boto3.client(clfn)
+        paginator = client.get_paginator(descfn)
+        for page in paginator.paginate():
+            response = response + page[topkey]
+        if response == []:
+            log.debug("Empty response for "+type+" id="+str(id)+" returning"); return True
+        for j in response:
+            bkarn = j.get('DBInstanceAutomatedBackupsArn')
+            srcarn = j.get('DBInstanceArn', '') or ''
+            src_region = srcarn.split(':')[3] if srcarn.count(':') >= 4 else ''
+            if bkarn and src_region and src_region != context.region:
+                common.write_import(type, bkarn, None)
+    except Exception as e:
+        common.handle_error(e, str(inspect.currentframe().f_code.co_name), clfn, descfn, topkey, id)
+
+    return True
+
+
 def get_aws_db_parameter_group(type, id, clfn, descfn, topkey, key, filterid):
 
 


### PR DESCRIPTION
### What
Getter correctness fixes:

- `aws_db_instance_automated_backups_replication`: collect only genuine cross-region replicas, keyed by the automated-backup ARN (the DB-instance ARN is rejected by the read filter; same-region backups aren't replication resources).
- `aws_db_snapshot`: collect only `manual` snapshots.
- `aws_backup_plan`: skip service-managed plans (rule name contains `/`), which can't be valid Terraform.
- `aws_transfer_workflow`: use `WorkflowId` (not the ARN) as the import id.

Fixes #149

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's LICENSE.
