### PR TITLE
fix: add unimportable resources to noimport (short-term) (#150)

### DIFF
--- a/code/fixtf_aws_resources/aws_no_import.py
+++ b/code/fixtf_aws_resources/aws_no_import.py
@@ -196,5 +196,7 @@ noimport = {
     "aws_ec2_allowed_images_settings": True, # import errors
     "aws_elastictranscoder_pipeline": True, # support withdrawn by aws
     "aws_elastictranscoder_preset": True, # support withdrawn by aws
-    "aws_vpc_block_public_access_exclusion": True # causes import error
-} 
+    "aws_vpc_block_public_access_exclusion": True, # causes import error
+    "aws_organizations_delegated_administrator": True, # import id needs ACCOUNTID/SERVICEPRINCIPAL; generic getter only has the account id
+    "aws_sagemaker_servicecatalog_portfolio_status": True # plan refresh needs sagemaker:GetSagemakerServicecatalogPortfolioStatus (often not granted)
+}


### PR DESCRIPTION
### What
Add two resources to `noimport` so they no longer break a full-account run:

- `aws_organizations_delegated_administrator` — import id needs `ACCOUNTID/SERVICEPRINCIPAL`, but the generic getter only has the account id.
- `aws_sagemaker_servicecatalog_portfolio_status` — the plan refresh needs `sagemaker:GetSagemakerServicecatalogPortfolioStatus`, which is often not granted.

Per the maintainer note on #150, this is the short-term handling while a longer-term approach is figured out.

Fixes #150

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's LICENSE.
