### PR TITLE
fix: robust de-referencing — sanitize names; keep literals for excluded/self/import-only targets (#143 #144 #145 #146)

### DIFF
--- a/code/common.py
+++ b/code/common.py
@@ -1851,6 +1851,11 @@ def splitf(input_file):
    with open(input_file, 'r') as f:
         content = f.read()
    
+   # generate-config-out can emit a provider-invalid stickiness { duration = 0 }
+   # (valid range is 1-604800); sanitize 0 -> 1 before splitting so the
+   # per-resource .out validates.
+   content = re.sub(r'(\n[ \t]*)duration = 0(?=\n)', r'\g<1>duration = 1', content)
+
     # Use a more efficient splitting method
    resource_blocks = re.split(r'(?=\nresource ")', '\n' + content)
 
@@ -1897,6 +1902,37 @@ def splitf(input_file):
 
 
 # if type == "aws_vpc_endpoint": return "ec2","describe_vpc_endpoints","VpcEndpoints","VpcEndpointId","vpc-id"
+
+def ref_skipped(type, name):
+   # True if a referenced resource was excluded (-e/--exclude) or skipped
+   # (--skipname). In that case the target resource is never generated, so deref
+   # handlers must keep the attribute as a literal id/ARN string rather than emit
+   # a dangling Terraform reference to a resource that does not exist.
+   if type in context.all_extypes:
+       return True
+   if context.skipname and name is not None and context.skipname.lower() in str(name).lower():
+       return True
+   return False
+
+
+def is_self_ref(type, name):
+   # True if a deref target is the resource currently being generated. Building a
+   # reference to it would create an illegal self-reference (Terraform rejects a
+   # block that refers to itself, e.g. a role whose trust policy lists its own ARN).
+   return context.current_tf == type + "__" + name
+
+
+def tfname(theid):
+   # Sanitize an identifier the same way write_import generates a resource label,
+   # so cross-resource references (e.g. aws_iam_user.<name>.id) match the declared
+   # resource name. Names containing '.', '@', spaces etc. would otherwise produce
+   # references Terraform parses as attribute access (aws_iam_user.first.last.id).
+   tfid=theid.replace("/","_").replace(".","_").replace(":","_").replace("|","_").replace("$","_").replace(",","_").replace("&","_").replace("#","_").replace("[","_").replace("]","_").replace("=","_").replace("!","_").replace(";","_").replace(" ","_").replace("*","star").replace("\\052","star").replace("@","_").replace("\\64","_")
+   if tfid[:1].isdigit(): tfid="r-"+tfid
+   tfid = re.sub(r'\.\.', '_', tfid)
+   tfid = tfid.replace('/', '_')
+   return tfid
+
 
 #generally pass 3rd param as None - unless overriding
 def write_import(type,theid,tfid):

--- a/code/context.py
+++ b/code/context.py
@@ -75,6 +75,7 @@ meshname=""
 workaround=""
 expected=False
 all_extypes=[]
+current_tf=""
 serverless=False
 dzd=""
 dzgid=""

--- a/code/fixtf.py
+++ b/code/fixtf.py
@@ -439,7 +439,10 @@ FIXTF_MODULES = {
 
 
 def fixtf(ttft,tf):
-  
+    # record the resource currently being generated so is_self_ref() can detect
+    # a deref target that is this same resource (illegal self-reference).
+    context.current_tf=tf
+
     rf=tf+".out"
     tf2=tf+".tf"
 
@@ -828,9 +831,16 @@ def globals_replace(t1,tt1,tt2):
             return t1
         
         if tt2.startswith("arn:aws:lambda") and "function:" in tt2:
+            if tt2.endswith("*"):
+                return t1
+            if tt1=="Resource":
+                return t1
             fname=tt2.split(":")[-1]
-            t1 = tt1 + " = aws_lambda_function." + fname + ".arn\n"
-            common.add_dependancy("aws_lambda_function", fname)
+            # only build a reference if the function was collected; otherwise
+            # (e.g. service-managed lambdas, or a policy Resource) keep the literal ARN
+            if fname in context.lambdalist and not common.ref_skipped("aws_lambda_function", fname) and not common.is_self_ref("aws_lambda_function", fname):
+                t1 = tt1 + " = aws_lambda_function." + fname + ".arn\n"
+                common.add_dependancy("aws_lambda_function", fname)
             return t1
 
         if tt2.startswith("arn:aws:cloudfront:") and ":distribution/" in tt2:
@@ -855,7 +865,7 @@ def globals_replace(t1,tt1,tt2):
             if len(arnparts) > 4 and arnparts[4] in ("", "*"):
                 return t1
             tt2=tt2.split('/')[-1]
-            if tt2 in context.rolelist:
+            if tt2 in context.rolelist and not common.ref_skipped("aws_iam_role", tt2) and not common.is_self_ref("aws_iam_role", tt2):
                 t1=tt1 + " = aws_iam_role." + tt2 + ".arn\n"
                 common.add_dependancy("aws_iam_role",tt2)
             return t1

--- a/code/fixtf_aws_resources/aws_common.py
+++ b/code/fixtf_aws_resources/aws_common.py
@@ -186,7 +186,7 @@ def aws_common(type,t1,tt1,tt2,flag1,flag2):
             if tt2 != "null":     
                 if "arn:" in tt2: 
                     tt2=tt2.split("/")[-1]
-                    if check_key(tt2):	
+                    if check_key(tt2) and not common.ref_skipped("aws_kms_key", tt2):	
                         if not context.dkms:
                             t1=tt1 + " = aws_kms_key.k-" + tt2 + ".arn\n"
                             common.add_dependancy("aws_kms_key",tt2)
@@ -213,7 +213,7 @@ def aws_common(type,t1,tt1,tt2,flag1,flag2):
                         if "arn:" in tt2:   
                             tt2=tt2.split("/")[-1]	
                             skip=0
-                            if check_key(tt2):
+                            if check_key(tt2) and not common.ref_skipped("aws_kms_key", tt2):
                                 if not context.dkms:
                                     t1=tt1 + " = aws_kms_key.k-" + tt2 + ".arn\n"
                                     common.add_dependancy("aws_kms_key",tt2) 
@@ -224,7 +224,7 @@ def aws_common(type,t1,tt1,tt2,flag1,flag2):
                         else:
                             tt2=tt2.split("/")[-1]
                             skip=0
-                            if check_key(tt2):
+                            if check_key(tt2) and not common.ref_skipped("aws_kms_key", tt2):
                                 if not context.dkms:
                                     t1=tt1 + " = aws_kms_key.k-" + tt2 + ".id\n"
                                     common.add_dependancy("aws_kms_key", tt2)

--- a/code/fixtf_aws_resources/fixtf_ec2.py
+++ b/code/fixtf_aws_resources/fixtf_ec2.py
@@ -170,9 +170,13 @@ def aws_instance(t1, tt1, tt2, flag1, flag2):
 		
 		elif tt1 == "iam_instance_profile":
 			if tt2 != "null":
-				if tt2 in str(context.inplist.keys()):
-					t1 = tt1 + " = aws_iam_instance_profile." + tt2 + ".name\n"
-					common.add_dependancy("aws_iam_instance_profile", tt2)
+				# Reference by literal name. Instance profiles are import-only
+				# (materialized via -generate-config-out); a TF reference to one breaks
+				# generate-config-out with "Reference to undeclared resource" and aborts
+				# the whole plan, so no import-only resource ever materializes. The
+				# profile is still collected (add_dependancy) and imported separately.
+				t1 = tt1 + " = \"" + tt2 + "\"\n"
+				common.add_dependancy("aws_iam_instance_profile", tt2)
 		
 		elif tt1 == "security_groups": skip = 1
 		

--- a/code/fixtf_aws_resources/fixtf_iam.py
+++ b/code/fixtf_aws_resources/fixtf_iam.py
@@ -29,7 +29,7 @@ def aws_iam_access_key(t1,tt1,tt2,flag1,flag2):
     if tt1 == "user":
         pkey="aws_iam_access_key."+tt2
         context.rproc[pkey]=True
-        t1=tt1+" = aws_iam_user."+tt2+".id\n"
+        t1=tt1+" = aws_iam_user."+common.tfname(tt2)+".id\n"
     return skip,t1,flag1,flag2
 
 
@@ -39,7 +39,7 @@ def aws_iam_group_membership(t1,tt1,tt2,flag1,flag2):
 
     skip=0
     if tt1=="user" and tt2 !="null":
-        t1=tt1+" = aws_iam_user."+tt2+".id\n"
+        t1=tt1+" = aws_iam_user."+common.tfname(tt2)+".id\n"
         common.add_dependancy("aws_iam_user", tt2)
 		
     return skip,t1,flag1,flag2
@@ -164,7 +164,7 @@ def aws_iam_user_group_membership(t1,tt1,tt2,flag1,flag2):
 
     skip=0
     if tt1 == "user":
-        t1=tt1+" = aws_iam_user."+tt2+".id\n"
+        t1=tt1+" = aws_iam_user."+common.tfname(tt2)+".id\n"
         common.add_dependancy("aws_iam_user", tt2)
     elif tt1 == "groups":
         t1,skip = fixtf.deref_array(t1, tt1, tt2, "aws_iam_group", "", skip)

--- a/code/fixtf_aws_resources/fixtf_lambda.py
+++ b/code/fixtf_aws_resources/fixtf_lambda.py
@@ -31,14 +31,18 @@ def aws_lambda_function(t1,tt1,tt2,flag1,flag2):
     skip=0
     if tt1 == "role":
         tt2=tt2.split("/")[-1]
-        if "." in tt2:
-            rn=tt2.replace(".","_")
-            t1=tt1 + " = aws_iam_role." + rn + ".arn\n"
+        if common.ref_skipped("aws_iam_role", tt2):
+            # role was excluded/skipped - keep the literal role ARN, not a dangling ref
+            pass
         else:
-            t1=tt1 + " = aws_iam_role." + tt2 + ".arn\n"
-        common.add_dependancy("aws_iam_role",tt2)
-        pkey="aws_iam_role"+"."+tt2
-        #context.rproc[pkey]=True
+            if "." in tt2:
+                rn=tt2.replace(".","_")
+                t1=tt1 + " = aws_iam_role." + rn + ".arn\n"
+            else:
+                t1=tt1 + " = aws_iam_role." + tt2 + ".arn\n"
+            common.add_dependancy("aws_iam_role",tt2)
+            pkey="aws_iam_role"+"."+tt2
+            #context.rproc[pkey]=True
 
     elif tt1 == "log_group":
         #aws_cloudwatch_log_group._aws_lambda_document-generator-handler.name
@@ -69,42 +73,18 @@ def aws_lambda_function(t1,tt1,tt2,flag1,flag2):
     ###### layers code
     elif tt1 == "layers" and tt2!="[]":
         if tt2 != "null" and "arn:" in tt2:
-            cc=tt2.count(',')
-            tt2=tt2.lstrip('[').rstrip(']')
-        else:
-             common.log_warning("WARNING: layers is not an array %s",  tt2)
-             return skip,t1,flag1,flag2
-        #if context.debug: 
-        builds=""
-        if cc > 0:
-            for i in range(cc+1):
-                subn=tt2.split(',')[i]
-                subn=subn.strip(" ").lstrip('"').rstrip('"').strip(" ")
-                if context.acc in subn:
-                    tarn=subn.replace("/","_").replace(".","_").replace(":","_").replace("|","_").replace("$","_").replace(",","_").replace("&","_").replace("#","_").replace("[","_").replace("]","_").replace("=","_").replace("!","_").replace(";","_")
-                    common.add_dependancy("aws_lambda_layer_version",subn)
-                    builds=builds+"aws_lambda_layer_version."+tarn+".arn,"
-                else:
-                    builds=builds+"\""+subn+"\", "
-            
-            if builds.endswith(','):
-                builds=builds.rstrip(',')
+            # Reference layer versions by literal ARN. Lambda layer versions are
+            # immutable and terraform's -generate-config-out does not materialize
+            # them as aws_lambda_layer_version resources, so a managed-resource
+            # reference would point at an undeclared resource. The literal ARN keeps
+            # the layer attached to the function and validates/imports correctly.
+            inner=tt2.lstrip('[').rstrip(']')
+            arns=[a.strip().strip('"').strip() for a in inner.split(',')]
+            arns=[a for a in arns if a]
+            builds=", ".join('"'+a+'"' for a in arns)
             t1 = tt1+" = ["+builds+"]\n"
-                
-        elif cc == 0:
-            if context.acc in tt2:  
-                tt2=tt2.lstrip('"').rstrip('"')
-                larn=tt2.split(":")[:-1]
-                myarn=""
-                for ta in larn:
-                    myarn=myarn+ta+":"
-                
-                myarn=myarn.rstrip(":")
-                tarn=tt2.replace("/","_").replace(".","_").replace(":","_").replace("|","_").replace("$","_").replace(",","_").replace("&","_").replace("#","_").replace("[","_").replace("]","_").replace("=","_").replace("!","_").replace(";","_")
-                # test we can get at it before sub
-                
-                t1 = tt1+" = [aws_lambda_layer_version."+tarn+ ".arn]\n"
-                common.add_dependancy("aws_lambda_layer_version",tt2)
+        else:
+            common.log_warning("WARNING: layers is not an array %s",  tt2)
 
     return skip,t1,flag1,flag2
 


### PR DESCRIPTION
### What
A small, consolidated set of de-referencing-robustness fixes. They share three new helpers in `common.py`, so they're submitted together rather than as conflicting separate PRs.

**New helpers** (`common.py`, `context.py`)
- `tfname()` — sanitize an id the same way `write_import` builds a resource label.
- `ref_skipped(type,name)` — target excluded (`-e`) or `--skipname`'d.
- `is_self_ref(type,name)` — target is the resource currently being generated.

**#143 — sanitize cross-resource reference names.** Build IAM user references with `tfname()` so a name like `first.last` (declared `aws_iam_user.first_last`) isn't emitted as `aws_iam_user.first.last.id` (parsed as attribute access).

**#144 — guard the Lambda-ARN deref in `globals_replace`.** Skip wildcard ARNs, skip when the attribute is a policy `Resource`, and only build a reference when the function was collected — otherwise keep the literal ARN.

**#145 — keep literals for excluded / skipped / self targets.** Guard the role and KMS derefs with `ref_skipped`/`is_self_ref` so excluded/`--skipname`'d targets and self-references stay literal instead of producing "Reference to undeclared resource" / "Self-referential block".

**#146 — reference import-only resources by literal value; sanitize generated config.**
- `aws_instance.iam_instance_profile` → literal name (a TF reference aborts `generate-config-out`).
- `aws_lambda_function.layers` → literal ARNs (layer versions are immutable and not materialized by `generate-config-out`).
- sanitize `stickiness { duration = 0 } -> 1` when splitting `generate-config-out` output (valid range is 1-604800).

Fixes #143
Fixes #144
Fixes #145
Fixes #146

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's LICENSE.
