### PR TITLE
fix: treat computed-only plan updates as expected (NAT regional_nat_gateway_address) (#136)

### DIFF
--- a/code/common.py
+++ b/code/common.py
@@ -1297,7 +1297,24 @@ def tfplan3():
          nchanges = 0
          nallowedchanges = 0
          all_force_destroy_only = True  # Track if all changes are force_destroy only
-         
+
+         # "Computed-only" updates: the planned change's before == after, so no configured
+         # attribute differs and the update is driven solely by read-only/computed attributes
+         # that show as "(known after apply)" (e.g. aws_nat_gateway.regional_nat_gateway_address
+         # on AWS provider 6.27+). These are non-consequential, not unexpected, changes.
+         computed_only_addrs = set()
+         try:
+            _show = subprocess.run(['terraform', 'show', '-json', 'tfplan'],
+                                   capture_output=True, text=True)
+            _sp = json.loads(_show.stdout)
+            for _rc in _sp.get('resource_changes', []):
+               _ch = _rc.get('change', {})
+               if _ch.get('actions') == ['update'] and _ch.get('before') == _ch.get('after'):
+                  computed_only_addrs.add(_rc['address'])
+         except Exception as _e:
+            if context.debug:
+               log.debug("computed-only change detection skipped: %s", _e)
+
          with open('plan2.json') as f:
             for jsonObj in f:
                planDict = json.loads(jsonObj)
@@ -1336,6 +1353,7 @@ def tfplan3():
                
                if ctype == "aws_lb_listener" or ctype == "aws_cognito_user_pool_client" \
                   or ctype=="aws_bedrockagent_agent" or ctype=="aws_bedrockagent_agent_action_group" \
+                  or caddr in computed_only_addrs \
                   or force_destroy_only:
                   
                   changeList.append(pe['change']['resource']['addr'])

--- a/code/fixtf_aws_resources/fixtf_ec2.py
+++ b/code/fixtf_aws_resources/fixtf_ec2.py
@@ -248,8 +248,6 @@ def aws_nat_gateway(t1, tt1, tt2, flag1, flag2):
 		else:
 			t1 = tt1 + " = aws_eip." + tt2 + ".id\n"
 			common.add_dependancy("aws_eip", tt2)
-	elif tt1 == "vpc_id":
-		t1 = t1 + "\n lifecycle {\n   ignore_changes = [regional_nat_gateway_address]\n}\n"
 	return skip, t1, flag1, flag2
 
 


### PR DESCRIPTION
### What
Implements the surgical handling discussed in #136 (your "Option B ideally").

1. **`common.py` — treat *computed-only* updates as expected.** Before the plan-diff loop, parse the structured plan (`terraform show -json tfplan`) and collect addresses whose `change.before == change.after`. Such an `update` has no configured attribute difference — it is driven solely by read-only/computed attributes that plan as `(known after apply)` (e.g. `aws_nat_gateway.regional_nat_gateway_address` on AWS provider 6.27+). Those addresses are added to the allowed-change set. A *real* config drift (before != after) is still flagged as unexpected.

2. **`fixtf_ec2.py` — drop the redundant NAT `ignore_changes` injection.** `aws_nat_gateway` was emitting `lifecycle { ignore_changes = [regional_nat_gateway_address] }`, which is redundant on a read-only attribute (Terraform warns and it doesn't suppress the diff). The computed-only detection above handles it generically.

This is schema-free and general (any resource whose only diff is a computed attribute), not NAT-specific. The coarse alternative (adding `aws_nat_gateway` to the type allowlist) remains available if you'd prefer it.

Fixes #136

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's LICENSE.
