### PR TITLE
fix: more provider-schema/handler conformance (vpn, server cert, elasticache subnet group) (#159)

### DIFF
--- a/code/fixtf_aws_resources/aws_common.py
+++ b/code/fixtf_aws_resources/aws_common.py
@@ -126,7 +126,13 @@ def aws_common(type,t1,tt1,tt2,flag1,flag2):
 
 
 
-        elif tt1 == "subnets" or tt1 == "subnet_ids" or tt1 == "client_subnets": t1,skip = fixtf.deref_array(t1,tt1,tt2,"aws_subnet","subnet-",skip)
+        elif tt1 == "subnets" or tt1 == "subnet_ids" or tt1 == "client_subnets":
+            # subnet_ids is required for elasticache subnet groups; keep an empty
+            # list literal rather than dropping the line (deref_array skips []).
+            if tt1 == "subnet_ids" and tt2 == "[]" and type == "aws_elasticache_subnet_group":
+                t1 = tt1 + " = []\n"
+            else:
+                t1,skip = fixtf.deref_array(t1,tt1,tt2,"aws_subnet","subnet-",skip)
         elif tt1 == "route_table_ids": t1,skip = fixtf.deref_array(t1,tt1,tt2,"aws_route_table","rtb-",skip)
         elif tt1 == "iam_roles": t1=fixtf.deref_role_arn_array(t1,tt1,tt2)
         elif tt1 == "secret_arn_list": t1=fixtf.deref_secret_arn_array(t1,tt1,tt2)

--- a/code/fixtf_aws_resources/fixtf_ec2.py
+++ b/code/fixtf_aws_resources/fixtf_ec2.py
@@ -460,6 +460,10 @@ def aws_vpc_endpoint_service(t1, tt1, tt2, flag1, flag2):
 def aws_vpn_connection(t1, tt1, tt2, flag1, flag2):
 	skip = 0
 	if tt1.startswith("tunnel") and tt2 == "0": skip = 1
+	# enable_acceleration / tunnel_bandwidth are only valid for transit-gateway
+	# VPNs; drop their defaults so vpn_gateway_id (VGW) connections validate.
+	elif tt1 == "enable_acceleration" and tt2 == "false": skip = 1
+	elif tt1 == "tunnel_bandwidth" and tt2 == "standard": skip = 1
 	return skip, t1, flag1, flag2
 
 

--- a/code/fixtf_aws_resources/fixtf_iam.py
+++ b/code/fixtf_aws_resources/fixtf_iam.py
@@ -159,6 +159,19 @@ def aws_iam_role_policy_attachment(t1,tt1,tt2,flag1,flag2):
 
 
 
+def aws_iam_server_certificate(t1,tt1,tt2,flag1,flag2):
+
+
+    skip=0
+    if tt1 == "private_key":
+        # AWS never returns the private key, so it is exported as null. private_key
+        # is a required argument, so emit a placeholder and ignore changes to it -
+        # this lets the imported certificate validate without the real (unrecoverable) key.
+        t1='  private_key       = "IMPORT_PLACEHOLDER_PRIVATE_KEY" # sensitive - not retrievable from AWS\n  lifecycle {\n    ignore_changes = [private_key]\n  }\n'
+    return skip,t1,flag1,flag2
+
+
+
 def aws_iam_user_group_membership(t1,tt1,tt2,flag1,flag2):
 
 

--- a/code/fixtf_aws_resources/fixtf_kms.py
+++ b/code/fixtf_aws_resources/fixtf_kms.py
@@ -29,8 +29,7 @@ def aws_kms_key(t1,tt1,tt2,flag1,flag2):
 	if tt1=="tags":
 		context.kmskeyid=False
 	skip=0
-	if tt1 == "policy": 
-		print("passing:",t1)
+	if tt1 == "policy":
 		t1=fixtf.globals_replace(t1,tt1,tt2)
 	elif tt1=="rotation_period_in_days" and tt2=="0": skip=1
 	return skip,t1,flag1,flag2 


### PR DESCRIPTION
### What
A few small, independent provider-schema / handler conformance fixes (grouped per #159).

- **`aws_vpn_connection`** (`fixtf_ec2.py`) — drop `enable_acceleration = false` and `tunnel_bandwidth = "standard"`; they're transit-gateway-only and fail validate on a VGW connection.
- **`aws_iam_server_certificate`** (`fixtf_iam.py`) — new handler: AWS never returns `private_key` (required arg), so emit a placeholder and `ignore_changes = [private_key]` so the imported cert validates without the unrecoverable key.
- **`aws_elasticache_subnet_group`** (`aws_common.py`) — keep an empty-list literal for the required `subnet_ids` instead of letting the array-deref drop it.
- **minor** (`fixtf_kms.py`) — remove a leftover `print("passing:", t1)` debug line.

Fixes #159

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's LICENSE.
