### PR TITLE
fix: stage 6 stashing with truncated filenames; strip null TGW block from client VPN endpoints

### DIFF
--- a/aws2tf.py
+++ b/aws2tf.py
@@ -1018,6 +1018,22 @@ def process_known_dependencies():
     common.tfplan2()
 
 
+def stash_generated_tf(lc):
+    """Move generated configs to imported/ so the next plan re-generates them.
+
+    Globs the aws_*__*.tf files directly rather than deriving their names from
+    the import__*.tf files: filenames longer than 255 chars are truncated at
+    different points for the two (import_writer.write_import vs cmd_runner.splitf),
+    so a derived name can miss the real config, leaving a stale .tf in the root
+    that references resources which were stashed - failing plan and validate.
+    """
+    for fil in tqdm(glob.glob("aws_*__*.tf"), desc=f"Moving files (loop {lc})", unit="file", leave=False):
+        try:
+            shutil.move(fil, f"imported/{fil}")
+        except (FileNotFoundError, shutil.Error):
+            pass  # File already moved or doesn't exist
+
+
 def process_detected_dependencies():
     """Process detected dependencies with iterative loops (Stage 5-6)."""
     import timed_interrupt
@@ -1097,13 +1113,7 @@ def process_detected_dependencies():
         context.esttime = len(x)/4
         
         # Move files efficiently using shutil (10-50x faster than subprocess)
-        if len(x) > 0:
-            for fil in tqdm(x, desc=f"Moving files (loop {lc})", unit="file", leave=False):
-                tf = fil.split('__',1)[1]
-                try:
-                    shutil.move(tf, f"imported/{tf}")
-                except (FileNotFoundError, shutil.Error):
-                    pass  # File already moved or doesn't exist
+        stash_generated_tf(lc)
         
         context.tracking_message = "Stage 6 of 10, Dependancies Detection: Loop "+str(lc)+" terraform plan"
         common.tfplan1("loop "+str(lc))

--- a/code/fixtf.py
+++ b/code/fixtf.py
@@ -497,6 +497,7 @@ def fixtf(ttft,tf):
     context.elasticc=False
     context.kinesismsk=False
     context.destbuck=False
+    context.cvpntgw=False
 
 
     if ttft=="aws_s3_bucket_replication_configuration":
@@ -584,6 +585,17 @@ def fixtf(ttft,tf):
             if tt1=="destination_arn":
                 if tt2 == "null": context.levsmap=True
 
+    if ttft=="aws_ec2_client_vpn_endpoint":
+        for t1 in Lines:
+            t1=t1.strip()
+            tt1=t1.split("=")[0].strip()
+            try:
+                tt2=t1.split("=")[1].strip().strip('\"')
+            except:
+                tt2=""
+            if tt1=="transit_gateway_id":
+                if tt2 != "null": context.cvpntgw=True
+
     accessl=0
     cnxl=0
     context.lbskipaacl=False
@@ -642,6 +654,13 @@ def fixtf(ttft,tf):
 
     if ttft=="aws_instance":
         context.stripblock="primary_network_interface {"
+        context.stripstart="{"
+        context.stripend="}"
+
+    # transit_gateway_configuration conflicts with security_group_ids; strip the
+    # generated null-filled block unless the endpoint really is TGW-attached
+    if ttft=="aws_ec2_client_vpn_endpoint" and not context.cvpntgw:
+        context.stripblock="transit_gateway_configuration {"
         context.stripstart="{"
         context.stripend="}"
 

--- a/code/fixtf_aws_resources/fixtf_ec2.py
+++ b/code/fixtf_aws_resources/fixtf_ec2.py
@@ -68,6 +68,14 @@ def aws_default_security_group(t1, tt1, tt2, flag1, flag2):
 	return skip, t1, flag1, flag2
 
 
+def aws_ec2_client_vpn_endpoint(t1, tt1, tt2, flag1, flag2):
+	skip = 0
+	if tt1 == "security_group_ids" and context.cvpntgw:
+		# conflicts with transit_gateway_configuration on TGW-attached endpoints
+		skip = 1
+	return skip, t1, flag1, flag2
+
+
 def aws_ec2_managed_prefix_list(t1, tt1, tt2, flag1, flag2):
 	skip = 0
 	if tt1 == "max_entries":


### PR DESCRIPTION
Two fixes for failures hit during full-account runs (`aws2tf.py -f`), both ending in `exit 020` at validation. With both applied, a full run of a large account (several thousand resources) completes end-to-end: `Plan: N to import, 0 to add, 0 to change, 0 to destroy`, import applied, post-import plan clean.

## Fix 1 — Stage 6 stashing misses configs with truncated filenames

**Problem.** Full-account runs fail at the final validation with `Reference to undeclared resource` when the account contains resources whose generated filenames exceed the 255-character filesystem limit — typically `aws_wafv2_web_acl_association`, whose import id is `<web-acl-arn>,<resource-arn>`.

**Root cause.** Each Stage 6 dependency-detection loop stashes the generated `aws_*__*.tf` configs into `imported/` so that `terraform plan -generate-config-out` regenerates them. The stash step derived each config filename from its `import__*.tf` filename (`fil.split('__',1)[1]`). Filenames longer than 255 chars are truncated independently in two places:

- `import_writer.write_import`: `fn[:250]+".tf"`
- `cmd_runner.splitf`: `filename[:250]+".out"`

Because the `import__` prefix shifts the truncation point, the derived name never matches the real config file for long ids. The stale `.tf` is left in the root while the resources it references are stashed, so the next `plan -generate-config-out` fails with `Reference to undeclared resource`, `resources.out` is never produced, nothing is regenerated, and `terraform validate` then fails the same way.

**Fix.** Move the stash step into a helper (`stash_generated_tf`) that globs `aws_*__*.tf` directly and moves whatever actually exists, instead of reconstructing names from the import files. `import__*.tf`, `data-*.tf` and `provider.tf` are unaffected.

## Fix 2 — client VPN endpoint: `transit_gateway_configuration` conflicts with `security_group_ids`

**Problem.** With AWS provider 6.53.0, importing any VPC-associated `aws_ec2_client_vpn_endpoint` fails validation:

```
Error: Conflicting configuration arguments
"transit_gateway_configuration": conflicts with security_group_ids
```

**Root cause.** `terraform plan -generate-config-out` emits a `transit_gateway_configuration` block with null members for every client VPN endpoint, and the provider declares that block as conflicting with `security_group_ids`.

**Fix.** Following the existing prescan/stripblock patterns in `fixtf.py`: prescan the generated config for a real `transit_gateway_id`; when it is null, strip the whole `transit_gateway_configuration` block; when the endpoint really is TGW-attached, keep the block and drop `security_group_ids` instead (new handler in `fixtf_ec2.py`).

## Testing

- Full-account run on a large account (several thousand resources, including seven WAFv2 web ACL/ALB associations with >255-char filenames and a VPC-associated client VPN endpoint): previously exited 020; now completes with `0 to add, 0 to change, 0 to destroy` and a clean import.
- `stash_generated_tf` exercised standalone with a truncated-import-name + full-length-config pair, a short-name pair, and `data-*/provider.tf` files: both configs are stashed, import blocks and data/provider files stay put.
- `fixtf` exercised standalone against a real generated client VPN `.out` (null TGW block: block stripped, `security_group_ids` kept, braces balanced) and a synthesized TGW-attached variant (block kept, `security_group_ids` dropped).
