### PR TITLE
fix: plan-error file removals are silent no-ops (shutil.move does not expand wildcards)

### DIFF
--- a/code/terraform_runner.py
+++ b/code/terraform_runner.py
@@ -225,6 +225,14 @@ def run_terraform_apply_with_progress(tfplan_file, plan_json='plan2.json'):
         return rc(command)
 
 
+def move_to_notimported(pattern):
+   """shutil.move does not expand wildcards - glob and move each match."""
+   os.makedirs("notimported", exist_ok=True)
+   for f in glob.glob(pattern):
+      log.error("ERROR: moved "+f+" to notimported/")
+      shutil.move(f, os.path.join("notimported", f))
+
+
 def tfplan1(mymess):
 
    rf = "resources.out"
@@ -269,8 +277,7 @@ def tfplan1(mymess):
                         log.error("ERROR: Removing "+i +
                               " import files - plan errors see plan1.json [p1]")
                         context.badlist = context.badlist+[i]
-                        shutil.move("import__*"+i+"*.tf",
-                                    "notimported/import__*"+i+"*.tf")
+                        move_to_notimported("import__*"+i+"*.tf")
 
                   elif "Error: Cannot import non-existent remote object" in mess:
                      log.error(
@@ -280,8 +287,7 @@ def tfplan1(mymess):
                         log.error("ERROR: Removing "+i +
                               " import files - plan errors see plan1.json [p2]")
                         context.badlist = context.badlist+[i]
-                        shutil.move("import__*"+i+"*.tf",
-                                    "notimported/import__*"+i+"*.tf")
+                        move_to_notimported("import__*"+i+"*.tf")
 
                except:
                   pass
@@ -292,10 +298,8 @@ def tfplan1(mymess):
                      log.error("ERROR: Removing "+i +
                            " files - plan errors see plan1.json [p3]")
                      context.badlist = context.badlist+[i]
-                     shutil.move("import__*"+i+"*.tf",
-                                 "notimported/import__*"+i+"*.tf")
-                     shutil.move("aws_*"+i+"*.tf",
-                                 "notimported/aws_*"+i+"*.tf")
+                     move_to_notimported("import__*"+i+"*.tf")
+                     move_to_notimported("aws_*"+i+"*.tf")
 
                except:
                   if context.debug is True:
@@ -331,12 +335,8 @@ def tfplan2():
    # zap the badlist
    for i in context.badlist:
       log.error("ERROR: Removing "+i+" files - plan errors see plan1.json [p4]")
-      try:
-         shutil.move("aws_*"+i+"*.tf", "notimported/aws_*"+i+"*.tf")
-         shutil.move("aws_*"+i+"*.out", "notimported/aws_*"+i+"*.out")
-      except FileNotFoundError as e:
-         log.error(f"{e=}")
-         pass
+      move_to_notimported("aws_*"+i+"*.tf")
+      move_to_notimported("aws_*"+i+"*.out")
 
    # copy all imported/aws_*.tf to here ?
    com = "cp imported/aws_*.tf ."


### PR DESCRIPTION
## Problem

When `terraform plan` reports an error during the dependency loops (for example `Error: Cannot import non-existent remote object`, which happens whenever a resource is deleted between listing and planning), aws2tf logs `ERROR: Removing <id> import files - plan errors see plan1.json` — but the files are never actually removed. The same plan error then recurs on every subsequent plan, and since Stage 7 exits on any fatal plan error (`exit 021`), runs that were designed to self-heal fail instead.

## Root cause

The removal sites in `tfplan1`/`tfplan2` pass wildcard patterns straight to `shutil.move`:

```python
shutil.move("import__*"+i+"*.tf", "notimported/import__*"+i+"*.tf")
```

`shutil.move` does not expand wildcards, so the source path (a literal string containing `*`) never exists. The resulting `FileNotFoundError` is swallowed by the surrounding `try/except` handlers, making every plan-error removal — [p1] VPC Lattice 404, [p2] non-existent remote object, [p3] generic, and the [p4] badlist sweep in `tfplan2` — a silent no-op.

## Fix

Add `move_to_notimported(pattern)`, which expands the pattern with `glob.glob` and moves each match into `notimported/` (creating the directory if needed, and logging each file it moves), and call it at all removal sites. The error-message parsing and the match patterns themselves are unchanged — this only makes the intended move actually happen, and moved files remain recoverable under `notimported/`.

## Testing

- `move_to_notimported` exercised standalone: matching `import__*<id>*.tf` / `aws_*<id>*.tf` / `aws_*<id>*.out` files are moved into `notimported/`, non-matching patterns are a no-op without raising, unrelated files stay put, and re-moving after regeneration overwrites cleanly.
- The surrounding error-detection paths are untouched; exercising them end-to-end requires a run in which a resource disappears between listing and planning, so that scenario is verified at the unit level only.
