### PR TITLE
fix: don't import aws_organizations_organization when org reads are denied (#167)

### DIFF
--- a/code/get_aws_resources/aws_organizations.py
+++ b/code/get_aws_resources/aws_organizations.py
@@ -20,26 +20,30 @@ def get_aws_organizations_organization(type, id, clfn, descfn, topkey, key, filt
 
             if response == []: log.debug("Empty response for "+type+ " id="+str(id)+" returning"); return True
             j = response[topkey]
-  
-            common.write_import(type,j[key],None) 
+
+            # describe_organization works from any member account, but terraform reads this
+            # resource with list_roots/list_accounts - importing it without those fails the plan
             response2=[]
             try:
                 response2=client.list_roots()
-
-                if response2 == []: log.info("Empty response2 for list_roots id="+str(id)+" returning"); return True
-                for j in response2['Roots']:
-                    #common.add_known_dependancy("aws_organizations_policy", j[key])
-                    common.add_known_dependancy("aws_organizations_organizational_unit", j['Id'])
+                client.list_accounts()
             except Exception as e:
                 exc_type, exc_obj, exc_tb = sys.exc_info()
             #fname = os.path.split(exc_tb.tb_frame.f_code.co_filename)[1]
                 exn=str(exc_type.__name__)
                 if exn == "AccessDeniedException":
-                    log.info("Can't list_roots - no access or not a master account......")              
+                    log.info("Can't read organization - no access or not a master account......")
                     return True
                 #else:
                 #    print(f"{e=} [org1]")
                 #    return True
+
+            common.write_import(type,j[key],None)
+
+            if response2 == []: log.info("Empty response2 for list_roots id="+str(id)+" returning"); return True
+            for j in response2['Roots']:
+                #common.add_known_dependancy("aws_organizations_policy", j[key])
+                common.add_known_dependancy("aws_organizations_organizational_unit", j['Id'])
 
 
     except Exception as e:


### PR DESCRIPTION
Fixes #167.

## Problem

Running `./aws2tf.py` from an account that is a **member** of an AWS Organization (rather than the management account) aborts the entire run at Stage 7:

```
Stage 7 of 10, Penultimate Terraform Plan ...
Plan: N to import, 0 to add, 0 to change, 0 to destroy
================================================================================
TERRAFORM PLAN ERROR DETECTED:
--------------------------------------------------------------------------------
Error Message: Error: reading Organizations Organization (o-xxxxxxxxxx) accounts: operation
error Organizations: ListAccounts, https response error StatusCode: 400,
AccessDeniedException: You don't have permissions to access this resource.
================================================================================
-->> Plan 2 errors exiting - check plan2.json - or run terraform plan
exit 021
```

Nothing is imported — one unreadable resource takes the whole run down.

## Cause

`get_aws_organizations_organization` writes the import block on the strength of `describe_organization()`, which **any member account is allowed to call**, and only *afterwards* probes `list_roots()`:

```python
common.write_import(type,j[key],None)      # <-- import block already written
response2=[]
try:
    response2=client.list_roots()
    ...
except Exception as e:
    ...
    if exn == "AccessDeniedException":
        log.info("Can't list_roots - no access or not a master account......")
        return True                        # <-- too late; the import block is on disk
```

The AccessDenied branch returns cleanly, but `import__aws_organizations_organization__o-xxxxxxxxxx.tf` has already been written. Terraform's read of `aws_organizations_organization` calls `ListAccounts`/`ListRoots`, which a member account cannot do, so `terraform plan` fails on a resource that should never have been imported. Stage 7 has no removal path for that error and exits `021` — and the stage-6 self-heal that might otherwise have caught it is unreachable (filed separately as #168).

The run's own logs already know the answer several stages earlier — every *other* org getter skips itself correctly:

```
Can't list_accounts - no access or not a master account......
Can't list_roots - no access or not a master account......
```

`aws_organizations_organization` is the only one that doesn't.

This looks like the Python-implementation regression of #51, which reported the same `listing AWS Organization (...) accounts: AccessDeniedException` against the bash version and was fixed there.

## Fix

Run the access probe *before* writing the import block, and probe `list_accounts()` as well — that is the exact call the provider fails on. On `AccessDeniedException`, return without importing.

Deliberately **not** an `aws_no_import` entry (the short-term approach preferred in #150): unlike the resources discussed there, this one *does* import cleanly — just not from a member account. A blanket `noimport` would regress management-account runs, including the OU work in #165.

A permission probe is also more accurate than comparing `MasterAccountId` against the caller: delegated-administrator accounts are permitted the org read APIs, and they keep working with a probe.

## Behaviour change

Only the AccessDenied path changes:

| scenario | before | after |
|---|---|---|
| management account (all reads OK) | import + OU deps | unchanged (one extra `ListAccounts` call) |
| member account (`ListRoots`/`ListAccounts` denied) | import written → **plan fails, run aborts** | no import; logged and skipped |
| `ListAccounts` denied only | import written → plan fails | no import |
| non-AccessDenied error (e.g. throttling) | import written, OU walk skipped | unchanged |

## Testing

Environment: aws2tf v6273, terraform 1.15.8, AWS provider 6.53.0, boto3 1.43.38, Python 3.12.

- **Repro** is from a real run against an Organizations member account: Stage 7 aborted with the error above, importing nothing.
- The four scenarios in the table above were exercised offline with `boto3`/`common`/`context` stubbed out: management account still writes the import and queues the root OUs; member account writes nothing; `ListAccounts`-denied-only writes nothing; a non-AccessDenied error (throttling) still writes the import and skips the OU walk, exactly as before.

Being straight about the gaps:

- I have not yet re-run the full end-to-end import on the affected account with this patch applied — I'll confirm in a comment once I have.
- I have no management account to test against, so that path rests on the stubs plus inspection: the `write_import` call and the roots walk are unchanged apart from ordering.
- There's no `tests/` directory in the repo to add a regression test to — happy to contribute one if you'd like a test harness bootstrapped.

No conflict with #165 — different function, non-adjacent hunks.
