### PR TITLE
fix: keep literal arn in aws:SourceArn policy conditions - terraform cycle (#170)

### DIFF
--- a/code/fixtf.py
+++ b/code/fixtf.py
@@ -858,6 +858,11 @@ def globals_replace(t1,tt1,tt2):
                 return t1
             if tt1=="Resource":
                 return t1
+            # a policy condition ("aws:SourceArn") naming the function that uses this role:
+            # referencing it would make the role depend on a lambda that already depends on
+            # the role - aws allows it, terraform can't order it and errors with a cycle
+            if tt1.strip('"').lower().endswith(":sourcearn"):
+                return t1
             # Only dereference if the function is in the current region
             arn_region = tt2.split(":")[3]
             if arn_region and arn_region != context.region:


### PR DESCRIPTION
Fixes #170.

## Problem

A full-account import aborts at validation with a dependency cycle:

```
Validate and Test Plan  ...

Error: Cycle: aws_lambda_function.my-function, aws_iam_role.my-function-role

Validation after fix failed - exiting
exit 020
```

The trigger is a lambda execution role whose trust policy restricts assumption to the very function that uses it, via an `aws:SourceArn` condition. Several vendor-supplied CloudFormation stacks emit execution roles shaped like this, so it isn't an unusual shape - and it takes the whole run down, importing nothing.

What `generate-config-out` produces:

```hcl
resource "aws_iam_role" "my-function-role" {
  assume_role_policy = jsonencode({
    Statement = [{
      Action = "sts:AssumeRole"
      Condition = {
        ArnEquals = {
          "aws:SourceArn" = "arn:aws:lambda:<region>:<account>:function:my-function"
        }
      }
      Effect    = "Allow"
      Principal = { Service = "lambda.amazonaws.com" }
    }]
  })
}
```

fixtf then de-references that arn, so the role points at the function:

```hcl
"aws:SourceArn" = aws_lambda_function.my-function.arn     # role -> lambda   (added by fixtf)
```

while the function necessarily points back at the role:

```hcl
role = aws_iam_role.my-function-role.arn                  # lambda -> role   (legitimate)
```

AWS accepts the trust policy because the arn is predictable. Terraform cannot order the graph, so `validate` fails.

## Fix

Keep the literal arn when the attribute is an `aws:SourceArn` policy condition, mirroring the guard that already sits three lines above it for policy `Resource` elements:

```python
if tt1=="Resource":
    return t1
# a policy condition ("aws:SourceArn") naming the function that uses this role:
# referencing it would make the role depend on a lambda that already depends on
# the role - aws allows it, terraform can't order it and errors with a cycle
if tt1.strip('"').lower().endswith(":sourcearn"):
    return t1
```

This is the same principle as #137 (keep account-portable role arns literal in policy documents), extended from policy `Resource` elements to policy condition keys: an arn inside an IAM policy document should stay literal.

## Testing

Environment: aws2tf v6273, terraform 1.15.8, AWS provider 6.53.0, python 3.12.

- Reproduced on a full-account import (`-f`) that aborted at `exit 020`. With this change `terraform validate` passes, stage 7 plans clean (`0 to add, 0 to destroy`) and the run imports to completion.
- Checked every line shape that reaches this branch: `"aws:SourceArn"` and `"AWS:SourceArn"` now keep the literal; `Resource` still keeps the literal; an ordinary lambda arn attribute (`function_arn = "arn:aws:lambda:..."`) still de-references to `aws_lambda_function.<name>.arn`. Normal de-referencing is unaffected.
- I also built the resource dependency graph from the generated `.tf` files afterwards to confirm no cycles remained anywhere else in the config, not just the one terraform happened to report first.

## One caveat

The kept literal leaves the account id and region inline, exactly as the existing `Resource` guard does - the lambda branch returns before reaching the account/region `format(...)` substitution that other arn types get. Letting these fall through to that substitution would be the nicer end state, but it would also change the `Resource`, wildcard and cross-region cases, so I've kept it out of this fix. Happy to follow up if you want it.
