### PR TITLE
fix: log call has two format placeholders but one argument (#171)

### DIFF
--- a/code/get_aws_resources/aws_s3.py
+++ b/code/get_aws_resources/aws_s3.py
@@ -167,7 +167,7 @@ def get_all_s3_buckets(fb,my_region):
          return True
       
       if fb not in str(context.s3list.keys()):
-            log.info("Bucket %s not in s3list %s",  fb)
+            log.info("Bucket %s not in s3list", fb)
             pkey=type+"."+fb
             context.rproc[pkey]=True
             return True


### PR DESCRIPTION
Fixes #171.

## Problem

`get_all_s3_buckets` logs with two `%s` placeholders but passes one argument:

```python
log.info("Bucket %s not in s3list %s",  fb)
```

Every bucket that isn't in the s3 list therefore raises `TypeError: not enough arguments for format string` inside `logging`, which prints a full traceback - twice, once per handler - instead of the intended one-line message:

```
--- Logging error ---
Traceback (most recent call last):
  ...
  File "code/get_aws_resources/aws_s3.py", line 170, in get_all_s3_buckets
    log.info("Bucket %s not in s3list %s",  fb)
TypeError: not enough arguments for format string
Message: 'Bucket %s not in s3list %s'
Arguments: ('<bucket-name>',)
```

It is non-fatal, since `logging` swallows the error, but on a full-account run with cross-region replica buckets it produces pages of tracebacks and buries the real output.

## Fix

```python
log.info("Bucket %s not in s3list", fb)
```

## Testing

Full-account run (`-f`) on the affected account: ten of these tracebacks before, zero after, with the intended message logged instead.
