### PR TITLE
fix: only import a networkfirewall logging configuration that exists (#175)

### DIFF
--- a/code/get_aws_resources/aws_network_firewall.py
+++ b/code/get_aws_resources/aws_network_firewall.py
@@ -7,6 +7,18 @@ from botocore.config import Config
 import context
 import inspect
 
+def has_logging_configuration(client, arn):
+    """Network Firewall logging is optional - importing a logging configuration that isn't
+    there fails the plan with "Cannot import non-existent remote object"."""
+    try:
+        response = client.describe_logging_configuration(FirewallArn=arn)
+    except Exception as e:
+        log.info("Can't describe_logging_configuration for "+str(arn)+" - not importing one")
+        return False
+    lc = response.get('LoggingConfiguration') or {}
+    return bool(lc.get('LogDestinationConfigs'))
+
+
 def get_aws_networkfirewall_firewall(type, id, clfn, descfn, topkey, key, filterid):
     if context.debug:
         log.debug("--> In "+str(inspect.currentframe().f_code.co_name)+" doing " + type + ' with id ' + str(id) +
@@ -23,10 +35,11 @@ def get_aws_networkfirewall_firewall(type, id, clfn, descfn, topkey, key, filter
                 if context.debug: log.debug("Empty response for "+type+ " id="+str(id)+" returning") 
                 return True
             for j in response:
-                common.write_import(type,j[key],None) 
-                common.write_import("aws_networkfirewall_logging_configuration",j[key],None) 
+                common.write_import(type,j[key],None)
+                if has_logging_configuration(client, j[key]):
+                    common.write_import("aws_networkfirewall_logging_configuration",j[key],None)
 
-        else: 
+        else:
             if id.startswith("arn:"):
                 response = client.describe_firewall(FirewallArn=id)
             else:      
@@ -36,7 +49,8 @@ def get_aws_networkfirewall_firewall(type, id, clfn, descfn, topkey, key, filter
                 return True
             j=response['Firewall']
             common.write_import(type,j[key],None)
-            common.write_import("aws_networkfirewall_logging_configuration",j[key],None) 
+            if has_logging_configuration(client, j[key]):
+                common.write_import("aws_networkfirewall_logging_configuration",j[key],None)
 
     except Exception as e:
         common.handle_error(e,str(inspect.currentframe().f_code.co_name),clfn,descfn,topkey,id)


### PR DESCRIPTION
Fixes #175.

## Problem

`get_aws_networkfirewall_firewall` writes an import block for the logging configuration of every firewall it finds. Network Firewall logging is optional, so for a firewall with logging disabled terraform has nothing to import:

```
Error: Cannot import non-existent remote object

While attempting to import an existing object to
"aws_networkfirewall_logging_configuration.arn_aws_network-firewall_<region>_<account>_firewall_myfirewall",
the provider detected that no object exists with the given id.
```

## Fix

Check first, and only import a logging configuration that is actually there:

```python
def has_logging_configuration(client, arn):
    """Network Firewall logging is optional - importing a logging configuration that isn't
    there fails the plan with "Cannot import non-existent remote object"."""
    try:
        response = client.describe_logging_configuration(FirewallArn=arn)
    except Exception as e:
        log.info("Can't describe_logging_configuration for "+str(arn)+" - not importing one")
        return False
    lc = response.get('LoggingConfiguration') or {}
    return bool(lc.get('LogDestinationConfigs'))
```

applied in both the list branch and the by-id branch.

## Testing

Environment: aws2tf v6273, terraform 1.15.8, AWS provider 6.53.0.

Full-account import (`-f`) of a region with a firewall that has logging disabled: no import block is now written for the absent logging configuration, the firewall itself still imports, and the run completes with `0 to add, 0 to change, 0 to destroy`.

## Sidenote

Not touched here, but worth knowing: the `aws_dict` entry for `aws_networkfirewall_logging_configuration` gives `list_logging_configurations` as its `descfn`, and that operation doesn't exist in the boto3 `network-firewall` client - only `describe_logging_configuration` does. Nothing reaches it today because this getter writes the import blocks directly. Happy to clean that up separately if you'd like.
