### PR TITLE
fix: keep aws_ssm_parameter values byte-exact (#178)

### DIFF
--- a/code/fixtf_aws_resources/fixtf_ssm.py
+++ b/code/fixtf_aws_resources/fixtf_ssm.py
@@ -46,6 +46,19 @@ def aws_ssm_maintenance_window(t1,tt1,tt2,flag1,flag2):
 
 
 
+def hcl_string(vs):
+	"""A byte-exact hcl string literal for an ssm parameter value.
+
+	jsonencode() re-serialises a json value - sorting its keys, dropping its whitespace - so it
+	never matches the string ssm actually stores, and terraform plans a change on every run.
+	Escaping the value instead keeps it byte for byte, whatever it holds.
+	"""
+	vs = vs.replace('\\', '\\\\').replace('"', '\\"')
+	vs = vs.replace('\n', '\\n').replace('\r', '\\r').replace('\t', '\\t')
+	vs = vs.replace('${', '$${').replace('%{', '%%{')
+	return '"' + vs + '"'
+
+
 def aws_ssm_parameter(t1,tt1,tt2,flag1,flag2):
 
 
@@ -58,15 +71,8 @@ def aws_ssm_parameter(t1,tt1,tt2,flag1,flag2):
 			client = boto3.client("ssm")
 			response = client.get_parameter(Name=context.ssmparamn, WithDecryption=True)
 			vs=response["Parameter"]["Value"]
-			ml=len(vs.split('\n'))
-			if ml > 1:
-				vs=vs.replace('\n','').replace('\t','')
-			vs=vs.replace('${','$${')
-			if vs.startswith('{"') or vs.startswith('["') :
-				t1 = tt1 + " = jsonencode("+vs+")\n"
-			else:
-				t1 = tt1 + " = \"" + vs + "\"\n"
-			context.ssmparamn=""	
+			t1 = tt1 + " = " + hcl_string(vs) + "\n"
+			context.ssmparamn=""
 	elif tt1 == "insecure_value": 
 		t1 ="lifecycle {\n" + "   ignore_changes = [value]\n" +  "}\n"
 		


### PR DESCRIPTION
Fixes #178.

## Problem

The value of an `aws_ssm_parameter` was written back as `jsonencode(<the json>)` whenever it looked like JSON. HCL parses that JSON and re-serialises it - sorting the keys, dropping the whitespace - so it never matches the string SSM actually stores, and terraform plans an in-place change on every run:

```
Plan: N to import, 0 to add, 2 to change, 0 to destroy
```

```
stored in ssm      {"version": "1.2.0", "features": { "scanning": true }, "region": "us-east-2"}
jsonencode emits   {"features":{"scanning":true},"region":"us-east-2","version":"1.2.0"}
```

A multi-line value fared worse: its newlines and tabs were stripped out altogether, which is a real content change rather than a cosmetic one - an `apply` would overwrite the parameter with the newlines gone. And the plain-string branch escaped nothing, so a value containing a double quote produced invalid HCL.

## Fix

```python
def hcl_string(vs):
	"""A byte-exact hcl string literal for an ssm parameter value.

	jsonencode() re-serialises a json value - sorting its keys, dropping its whitespace - so it
	never matches the string ssm actually stores, and terraform plans a change on every run.
	Escaping the value instead keeps it byte for byte, whatever it holds.
	"""
	vs = vs.replace('\\', '\\\\').replace('"', '\\"')
	vs = vs.replace('\n', '\\n').replace('\r', '\\r').replace('\t', '\\t')
	vs = vs.replace('${', '$${').replace('%{', '%%{')
	return '"' + vs + '"'
```

with the value branch reduced to:

```python
	elif tt1 == "value":
		if context.ssmparamn != "":
			client = boto3.client("ssm")
			response = client.get_parameter(Name=context.ssmparamn, WithDecryption=True)
			vs=response["Parameter"]["Value"]
			t1 = tt1 + " = " + hcl_string(vs) + "\n"
			context.ssmparamn=""
```

Escaping `%{` is new rather than restored - the old code never handled template directives at all, so a value containing `%{` would also have produced invalid HCL.

## Testing

Environment: aws2tf v6273, terraform 1.15.8, AWS provider 6.53.0.

Verified by handing the generated literal to terraform itself and asking what it read back - the value has to survive that round trip byte for byte, or the plan never converges:

| value | stored | terraform parsed back |
|---|---|---|
| real json parameter | 696 bytes | 696, identical |
| real json parameter | 684 bytes | 684, identical |
| multi-line, with tabs | 37 bytes | 37, identical (newlines were previously stripped) |
| embedded quotes and backslashes | 28 bytes | 28, identical (previously invalid HCL) |
| `${...}` | 26 bytes | 26, identical |
| `%{...}` | 33 bytes | 33, identical (previously not escaped at all) |

Full-account import (`-f`) of a region holding JSON-valued parameters: stage 7 previously reported `2 to change`; it now reports `0 to add, 0 to change, 0 to destroy`.

## Tradeoff

A JSON-valued parameter now appears as an escaped string literal rather than `jsonencode({...})`, which is harder to read. That's the cost of correctness - `jsonencode` is readable precisely *because* it normalises the JSON, and normalising it is what makes the resource un-importable without drift.
