### PR TITLE
fix: keep literal lambda ARNs account/region-portable (#170)

### DIFF
--- a/code/fixtf.py
+++ b/code/fixtf.py
@@ -826,6 +826,29 @@ def aws_resource(t1,tt1,tt2,flag1,flag2):
     return skip,t1,flag1,flag2 
 
 
+# Make an ARN we are deliberately keeping literal (not de-referencing to a resource
+# address) account/region-portable, by substituting this account's id/region with the
+# same data sources other ARN types get at the end of globals_replace. Used for lambda
+# ARNs we must keep literal to avoid a terraform dependency cycle (an aws:SourceArn
+# condition or policy Resource naming the function that owns the role - see #170), or that
+# we cannot dereference (another region, or a function that was not collected). An ARN in
+# a different account (context.acc not present) is left fully literal.
+def sub_acct_region(t1, tt1, tt2):
+    if ":" + context.acc + ":" not in tt2:
+        return t1
+    ends = ""
+    while ":" + context.acc + ":" in tt2:
+        r1 = tt2.find(":" + context.region + ":")
+        a1 = tt2.find(":" + context.acc + ":")
+        if r1 > 0 and r1 < a1:
+            ends = ends + ",data.aws_region.current.region"
+            tt2 = tt2[:r1] + ":%s:" + tt2[r1 + context.regionl + 2:]
+        a1 = tt2.find(":" + context.acc + ":")
+        tt2 = tt2[:a1] + ":%s:" + tt2[a1 + 14:]
+        ends = ends + ",data.aws_caller_identity.current.account_id"
+    return tt1 + ' = format("' + tt2 + '"' + ends + ')\n'
+
+
 # generic replace of acct and region in arn
 def globals_replace(t1,tt1,tt2):
     if context.debug: log.debug("GR start:%s",  t1)
@@ -854,26 +877,30 @@ def globals_replace(t1,tt1,tt2):
             return t1
         
         if tt2.startswith("arn:aws:lambda") and "function:" in tt2:
+            # The branches below keep the ARN literal rather than de-referencing it to
+            # aws_lambda_function.<name>.arn, but still make the account id / region
+            # portable via sub_acct_region instead of leaving them hard-coded inline.
             if tt2.endswith("*"):
-                return t1
+                return sub_acct_region(t1, tt1, tt2)
             if tt1=="Resource":
-                return t1
+                return sub_acct_region(t1, tt1, tt2)
             # a policy condition ("aws:SourceArn") naming the function that uses this role:
             # referencing it would make the role depend on a lambda that already depends on
             # the role - aws allows it, terraform can't order it and errors with a cycle
             if tt1.strip('"').lower().endswith(":sourcearn"):
-                return t1
+                return sub_acct_region(t1, tt1, tt2)
             # Only dereference if the function is in the current region
             arn_region = tt2.split(":")[3]
             if arn_region and arn_region != context.region:
-                return t1
+                return sub_acct_region(t1, tt1, tt2)
             fname=tt2.split(":")[-1]
             # only build a reference if the function was collected; otherwise
-            # (e.g. service-managed lambdas, or a policy Resource) keep the literal ARN
+            # (e.g. service-managed lambdas) keep the ARN literal but portable
             if fname in context.lambdalist and not common.ref_skipped("aws_lambda_function", fname) and not common.is_self_ref("aws_lambda_function", fname):
                 t1 = tt1 + " = aws_lambda_function." + fname + ".arn\n"
                 common.add_dependancy("aws_lambda_function", fname)
-            return t1
+                return t1
+            return sub_acct_region(t1, tt1, tt2)
 
         if tt2.startswith("arn:aws:cloudfront:") and ":distribution/" in tt2:
             fname=tt2.split("/")[-1]


### PR DESCRIPTION
Follow-up to the caveat noted on #172 (which fixed #170) — awsandy asked to fix it if I got the chance.

## Problem

`globals_replace` keeps certain lambda ARNs **literal** rather than de-referencing them to `aws_lambda_function.<name>.arn`:

- an `aws:SourceArn` policy condition naming the function that owns the role (de-referencing it cycles — the #170 / #172 case),
- a policy `Resource` element,
- a wildcard (`function:*`),
- a function in another region,
- a function not collected in this run (e.g. service-managed).

In every one of those the ARN was emitted with the account id and region **hard-coded inline**:

```hcl
"aws:SourceArn" = "arn:aws:lambda:<region>:<account>:function:my-function"
```

This is the caveat #172 called out: the lambda branch returns before reaching the account/region `format(...)` substitution that other ARN types get, so these ARNs are not account/region-portable.

## Fix

Route those literals through a new `sub_acct_region()` helper that substitutes this account's id/region with `data.aws_caller_identity.current.account_id` / `data.aws_region.current.region` — the same substitution the tail of `globals_replace` already applies to other ARN types:

```hcl
"aws:SourceArn" = format("arn:aws:lambda:%s:%s:function:my-function", data.aws_region.current.region, data.aws_caller_identity.current.account_id)
```

The **function name stays literal**, so the #172 cycle fix is preserved (the role still does not depend on the lambda). An ARN in a **different account** (this account's id not present) is left fully literal — de-referencing it to `data.aws_caller_identity` would be wrong.

## Behaviour change beyond the SourceArn case

#172 fixed only the `aws:SourceArn` cycle. This change also makes the **policy `Resource`, wildcard and cross-region** lambda literals account/region-portable — cases that previously kept account/region inline and worked, but were not portable. They now render as `format(...)` with data sources. The value produced at apply time is identical, so `terraform plan` shows no diff; flagging it because it is a behaviour change on paths that already worked.

## Testing

Environment: python 3.12, AWS provider 6.53.0.

- `globals_replace` exercised standalone against 7 line shapes: `aws:SourceArn` / policy `Resource` / wildcard / cross-region / uncollected-function all become portable `format(...)` literals with the function name kept literal; a **different-account** ARN stays fully literal; and an ordinary attribute for a **collected** function still de-references to `aws_lambda_function.<name>.arn` (unchanged). All 7 pass.
- Reproduced end-to-end on a real, vendor-supplied lambda execution role whose trust policy restricts assumption to its own function via an `aws:SourceArn` condition (the exact #170 shape). Imported the function and its role: `terraform validate` passes (no cycle), plan is `0 to add, 0 to change, 0 to destroy`, and the generated trust policy renders the condition as
  `"aws:SourceArn" = format("arn:aws:lambda:%s:%s:function:<name>", data.aws_region.current.region, data.aws_caller_identity.current.account_id)` —
  account/region portable, function name literal.
