### PR TITLE
fix: strip conflicting routing_rules from aws_s3_bucket_website_configuration (#181)

### DIFF
--- a/code/fixtf.py
+++ b/code/fixtf.py
@@ -498,6 +498,7 @@ def fixtf(ttft,tf):
     context.kinesismsk=False
     context.destbuck=False
     context.cvpntgw=False
+    context.s3routingdup=False
 
 
     if ttft=="aws_s3_bucket_replication_configuration":
@@ -596,6 +597,17 @@ def fixtf(ttft,tf):
             if tt1=="transit_gateway_id":
                 if tt2 != "null": context.cvpntgw=True
 
+    # generate-config-out emits the deprecated routing_rules (jsonencode) string
+    # alongside the routing_rule {} blocks; the provider marks them ConflictsWith.
+    # Only flag the duplicate when both are present, so we never strip the sole copy.
+    if ttft=="aws_s3_bucket_website_configuration":
+        rr_str=False; rr_block=False
+        for t1 in Lines:
+            s=t1.strip()
+            if s.startswith("routing_rules") and "jsonencode" in s: rr_str=True
+            if s.startswith("routing_rule {"): rr_block=True
+        if rr_str and rr_block: context.s3routingdup=True
+
     accessl=0
     cnxl=0
     context.lbskipaacl=False
@@ -661,6 +673,13 @@ def fixtf(ttft,tf):
     # generated null-filled block unless the endpoint really is TGW-attached
     if ttft=="aws_ec2_client_vpn_endpoint" and not context.cvpntgw:
         context.stripblock="transit_gateway_configuration {"
+        context.stripstart="{"
+        context.stripend="}"
+
+    # strip the conflicting deprecated routing_rules (jsonencode) block, keeping the
+    # routing_rule {} blocks that match the imported state (see prescan above)
+    if ttft=="aws_s3_bucket_website_configuration" and context.s3routingdup:
+        context.stripblock="routing_rules = jsonencode(["
         context.stripstart="{"
         context.stripend="}"
 


### PR DESCRIPTION
Fixes #181.

## Problem

A full-account import (`aws2tf.py -f`) aborts at Stage 8 validation (`exit 020`) for any bucket whose website configuration has routing rules:

```
Error: Conflicting configuration arguments

  "routing_rules": conflicts with routing_rule
```

`terraform plan -generate-config-out` emits **both** representations into the generated `aws_s3_bucket_website_configuration` — the deprecated `routing_rules = jsonencode([...])` string **and** the `routing_rule {}` blocks — and the provider declares them mutually exclusive (`ConflictsWith`). One invalid resource fails `terraform validate`, so the whole run aborts.

## Fix

Prescan the generated config; **only when both forms are present**, strip the deprecated `routing_rules = jsonencode(...)` block via the existing stripblock mechanism, keeping the `routing_rule {}` blocks (which match the imported state). When `routing_rules` is the only representation it is left untouched, so a routing configuration is never lost.

This mirrors the client-VPN `transit_gateway_configuration` strip: a prescan sets a flag, and the block is removed by the same generic brace-counting remover.

## Testing

Environment: aws2tf v6273, terraform 1.15.8, AWS provider 6.53.0, python 3.12.

- `fixtf` exercised standalone against three shapes of a generated website-configuration `.out`:
  - **both forms present** → `routing_rules` jsonencode stripped, both `routing_rule {}` blocks and `index_document {}` kept, braces balanced;
  - **only `routing_rules`** (no blocks) → left untouched (sole copy preserved);
  - **only `routing_rule {}` blocks** → untouched.
  All pass.
- Reproduced end-to-end: a full-account `-f` run that previously aborted at `exit 020` on this resource now generates the bucket with `routing_rules` removed and the `routing_rule {}` blocks retained, and validation moves past it.
