### PR TITLE
fix: handle S3 advanced_backup_setting in aws_backup_plan (strip + ignore_changes) (#183)

### DIFF
--- a/code/fixtf.py
+++ b/code/fixtf.py
@@ -438,6 +438,58 @@ FIXTF_MODULES = {
 ##############################################
 
 
+def strip_non_ec2_advanced_backup_settings(fname):
+    # aws_backup_plan.advanced_backup_setting only accepts resource_type "EC2"
+    # (Windows VSS) in the AWS provider, but AWS also returns S3 advanced settings
+    # (BackupACLs/BackupObjectTags) which generate-config-out emits and validate then
+    # rejects ("expected ... one of [\"EC2\"], got S3"). Drop each
+    # advanced_backup_setting block whose resource_type is not EC2, keeping any EC2
+    # blocks. A post-pass because resource_type sits at the end of the block, after
+    # the lines the main line-by-line loop has already written.
+    try:
+        with open(fname) as f:
+            lines = f.readlines()
+    except FileNotFoundError:
+        return
+    out = []
+    i = 0
+    n = len(lines)
+    changed = False
+    while i < n:
+        line = lines[i]
+        if line.strip().startswith("advanced_backup_setting {"):
+            depth = line.count("{") - line.count("}")
+            block = [line]
+            i += 1
+            while i < n and depth > 0:
+                block.append(lines[i])
+                depth += lines[i].count("{") - lines[i].count("}")
+                i += 1
+            keep = any(b.strip().startswith("resource_type") and '"EC2"' in b for b in block)
+            if keep:
+                out.extend(block)
+            else:
+                changed = True
+        else:
+            out.append(line)
+            i += 1
+    if not changed:
+        return
+    # AWS still returns the stripped (S3) advanced setting on read and the provider
+    # cannot express it in config, so terraform would otherwise plan a perpetual
+    # update. Ignore advanced_backup_setting so the import plans clean; insert the
+    # meta-block before the resource's own closing brace (a line that is just "}").
+    if not any("ignore_changes" in l and "advanced_backup_setting" in l for l in out):
+        for j in range(len(out) - 1, -1, -1):
+            if out[j].rstrip("\n") == "}":
+                out[j:j] = ["  lifecycle {\n",
+                            "    ignore_changes = [advanced_backup_setting]\n",
+                            "  }\n"]
+                break
+    with open(fname, "w") as f:
+        f.writelines(out)
+
+
 def fixtf(ttft,tf):
     # record the resource currently being generated so is_self_ref() can detect
     # a deref target that is this same resource (illegal self-reference).
@@ -812,6 +864,11 @@ def fixtf(ttft,tf):
         
         ## move *.out to impoted
         #shutil.move(rf, "imported/"+rf)
+
+    # drop advanced_backup_setting blocks the provider can't represent (resource_type
+    # other than EC2, e.g. S3) now that the config file is fully written and closed
+    if ttft == "aws_backup_plan":
+        strip_non_ec2_advanced_backup_settings(tf2)
 
 def remove_block():
 


### PR DESCRIPTION
Fixes #183.

## Problem

A full-account import aborts on any `aws_backup_plan` with an **S3** advanced backup setting. AWS Backup returns it (`BackupACLs`/`BackupObjectTags`, `resource_type = "S3"`) and `generate-config-out` emits it, but the provider's schema only accepts `resource_type = "EC2"` (Windows VSS):

- `terraform validate` rejects it — `expected ... one of ["EC2"], got S3` (exit 020);
- and once the block is removed, AWS still returns it on read, so the import plans a perpetual update (exit 025): `Plan: N to import, 0 to add, 1 to change, 0 to destroy`.

## Fix

A post-pass (`strip_non_ec2_advanced_backup_settings`) that:

1. drops each `advanced_backup_setting` block whose `resource_type` is not EC2 (keeping any EC2 block — a plan can carry both), and
2. when it drops one, injects `lifecycle { ignore_changes = [advanced_backup_setting] }` at the resource level so the import plans clean.

The provider cannot represent an S3 advanced setting in config, so strip + `ignore_changes` is the only route to a 0-change plan. Block-buffered because `resource_type` sits at the end of the block; the injected meta-block targets the resource's own closing brace (the `rule {}`'s nested retention `lifecycle` is left intact).

## Testing

Environment: aws2tf v6273, terraform 1.15.8, AWS provider 6.53.0, python 3.12.

- `fixtf` exercised standalone against three shapes (14 checks): **S3-only** → block dropped + `ignore_changes` injected + rule's retention lifecycle kept; **EC2-only** → kept, no `ignore_changes`; **mixed EC2+S3** → EC2 kept, S3 dropped, `ignore_changes` injected. All pass.
- Verified on the real generated `.out`: `advanced_backup_setting` removed and a resource-level `lifecycle { ignore_changes = [advanced_backup_setting] }` added, braces balanced.
- Full-account `-f` run: the backup plan that previously aborted the run (exit 020, then exit 025 after stripping) now plans `0 to change`; the run reaches a clean `Plan: N to import, 0 to add, 0 to change, 0 to destroy`.
