### PR TITLE
fix: make Stage-6 plan-error self-heal reachable, scoped to unrecoverable errors (#168)

### DIFF
--- a/code/terraform_runner.py
+++ b/code/terraform_runner.py
@@ -3,6 +3,7 @@
 import subprocess
 import os
 import json
+import re
 import time
 import glob
 import shutil
@@ -233,6 +234,26 @@ def move_to_notimported(pattern):
         shutil.move(f, os.path.join("notimported", f))
 
 
+# AccessDenied read diagnostics carry no address - only 'reading <Description>
+# (<name>): ...' in the summary - so map the human description to a terraform type.
+# Add entries as new resource families are seen to fail this way (issue #168).
+_READ_ERR_TYPE = {
+   "S3 Bucket Server-side Encryption Configuration": "aws_s3_bucket_server_side_encryption_configuration",
+   "S3 Bucket Versioning": "aws_s3_bucket_versioning",
+   "S3 Bucket Ownership Controls": "aws_s3_bucket_ownership_controls",
+   "S3 Bucket Request Payment Configuration": "aws_s3_bucket_request_payment_configuration",
+   "S3 Bucket Policy": "aws_s3_bucket_policy",
+   "S3 Bucket Object Lock Configuration": "aws_s3_bucket_object_lock_configuration",
+   "S3 Bucket Lifecycle Configuration": "aws_s3_bucket_lifecycle_configuration",
+   "Route 53 Record": "aws_route53_record",
+   "Route53 Hosted Zone": "aws_route53_zone",
+   "IAM OIDC Provider": "aws_iam_openid_connect_provider",
+   "IAM SAML Provider": "aws_iam_saml_provider",
+   "CodeStar Connections Connection": "aws_codestarconnections_connection",
+   "Glue Data Catalog Encryption Settings": "aws_glue_data_catalog_encryption_settings",
+}
+
+
 def tfplan1(mymess):
 
    rf = "resources.out"
@@ -256,65 +277,44 @@ def tfplan1(mymess):
    
    rout = run_terraform_plan_with_progress(com, "Terraform plan "+mymess)
       
-   file = "plan1.json"
-   f2 = open(file, "r")
-   plan2 = True
-
-   while True:
-      line = f2.readline()
-      if not line:
-         break
-      if '@level": "error"' in line:
-         if context.debug is True:
-            log.debug("Error" + line)
+   # Stage-6 self-heal (issue #168): terraform writes plan1.json as -json, one compact
+   # JSON object per line. Move genuinely unimportable resources to notimported/ so the
+   # run continues instead of aborting at Stage 7. Only errors terraform can never
+   # recover from are removed - a vanished or unreadable object; config-generation
+   # errors (Conflicting arguments, Missing required argument, ...) are left for fixtf.
+   with open("plan1.json") as f2:
+      for line in f2:
+         if '"@level":"error"' not in line:
+            continue
          try:
-               mess = f2.readline()
-               try:
-                  if "VPC Lattice" in mess and "404" in mess:
-                     log.error("ERROR: VPC Lattice 404 error - see plan1.json")
-                     i = mess.split('(')[1].split(')')[0].split('/')[-1]
-                     if i != "":
-                        log.error("ERROR: Removing "+i +
-                              " import files - plan errors see plan1.json [p1]")
-                        context.badlist = context.badlist+[i]
-                        move_to_notimported("import__*"+i+"*.tf")
+            diag = json.loads(line).get("diagnostic") or {}
+         except (ValueError, TypeError):
+            continue
+         summary = diag.get("summary", "") or ""
+         detail = diag.get("detail", "") or ""
 
-                  elif "Error: Cannot import non-existent remote object" in mess:
-                     log.error(
-                         "ERROR: Cannot import non-existent remote object - see plan1.json")
-                     i = mess.split('(')[1].split(')')[0].split('/')[-1]
-                     if i != "":
-                        log.error("ERROR: Removing "+i +
-                              " import files - plan errors see plan1.json [p2]")
-                        context.badlist = context.badlist+[i]
-                        move_to_notimported("import__*"+i+"*.tf")
+         # [p1]/[p2] unimportable import - the resource address is in detail
+         if summary == "Cannot import non-existent remote object" or ("VPC Lattice" in detail and "404" in detail):
+            m = re.search(r'import an existing object to "([^"]+)"', detail)
+            if m:
+               rtype, _, label = m.group(1).partition(".")
+               if label:
+                  log.error("ERROR: Removing %s - unimportable, see plan1.json [p2]", m.group(1))
+                  context.badlist = context.badlist + [label]
+                  move_to_notimported("import__" + rtype + "__" + label + "*.tf")
+            continue
 
-               except:
-                  pass
-
-               try:
-                  i = mess.split('(')[2].split(')')[0]
-                  if i != "":
-                     log.error("ERROR: Removing "+i +
-                           " files - plan errors see plan1.json [p3]")
-                     context.badlist = context.badlist+[i]
-                     move_to_notimported("import__*"+i+"*.tf")
-                     move_to_notimported("aws_*"+i+"*.tf")
-
-               except:
-                  if context.debug is True:
-                     log.debug(mess.strip())
-                  context.plan2 = True
-
-         except:
-               log.error("Error - no error message, check plan1.json")
-               dt = datetime.now().isoformat(timespec='seconds')
-               com = "cp plan1.json plan1.json."+dt
-               log.info(com)
-               rout = rc(com)
-               log.info("exit 018")
-               stop_timer()
-               exit()
+         # AccessDenied read - the resource can't be read so it can't be imported. These
+         # carry no address (detail empty); the identity is in summary as
+         # 'reading <Description> (<name>): ...', so map <Description> -> type.
+         if re.search(r'AccessDenied|StatusCode:\s*403|not authorized', summary):
+            m = re.match(r'reading (.+?) \((.+?)\): ', summary)
+            if m and _READ_ERR_TYPE.get(m.group(1)):
+               name = re.sub(r'[^A-Za-z0-9_-]', '_', m.group(2))
+               log.error("ERROR: Removing %s (%s) - AccessDenied, see plan1.json [p2r]", name, m.group(1))
+               context.badlist = context.badlist + [name]
+               move_to_notimported("import__" + _READ_ERR_TYPE[m.group(1)] + "__*" + name + "*.tf")
+            continue
 
    if not os.path.isfile("resources.out"):
          log.error("could not find expected resources.out file after Plan 1 - exiting")


### PR DESCRIPTION
Fixes #168.

## Problem

Stage 6's `plan1.json` error handler tested for `'@level": "error"'` (with a space), which terraform's compact `-json` never emits — so the self-heal block was **unreachable**, and a single unimportable resource survived to Stage 7, which has no removal path and aborts the whole run (`exit 021`). The message parsing underneath was also written for a multi-line format terraform doesn't produce (`mess = f2.readline()` + `mess.split('(')`).

## Fix

Rewrite `tfplan1`'s detection to parse `plan1.json` as JSON-lines and self-heal **only** errors terraform can never recover from — moving each resource's `import__` file to `notimported/`, and recording it in `badlist` so `tfplan2` drops its config too:

- **non-existent remote object / VPC Lattice 404** — the resource address is clean in `diagnostic.detail` (`import an existing object to "aws_x.y"`).
- **AccessDenied reads** — these carry *no* address (`detail` is empty); the identity is in `diagnostic.summary` as `reading <Description> (<name>): …`, so a small `<Description> → type` map (`_READ_ERR_TYPE`) resolves the type. **This is the part worth a look** — with no address to key off, the map has to be extended as new resource families are seen to fail this way.

The generic `[p3]` fallback is **dropped**, so the config-generation errors fixtf repairs later (Conflicting arguments, Missing required argument, …) are never removed.

## Validation

Standalone, against a real `plan1.json` (341 error diagnostics): **298/298** non-existent + **39/39** AccessDenied map to a real `import__` file, zero false positives.

Live full-account `-f` run on the account that first hit this (was `exit 021` on 341 errors):
- `notimported/` received exactly **337** files (`[p2]` 298 + `[p2r]` 39);
- `plan2.json` errors dropped **341 → 4**, and the penultimate plan came back `Plan: 103 to import, 0 to add, 0 to change, 0 to destroy`.

## Known residual (out of this scope — follow-ups)

That account still `exit 021`s on 4 leftover errors, all a different class from what this PR targets:

- `reading S3 Bucket Lifecycle Configuration (…): NoSuch…` — a **read** failure like AccessDenied but 404, not 403. Trivial follow-up: broaden the read trigger to `403 | 404 | NoSuch` (the type is already in the map). Left out here to keep this PR to the exact scope discussed.
- `Invalid Resource Import ID Value` ×1 and `couldn't find resource` ×1 — a bad / uninferrable import id generated for specific resources.
- one enum-validation error (`expected type to be one of ["password", …]`).

These are separate issues, not self-heal cases — happy to take them as follow-ups.
